### PR TITLE
Added API authentication to Gluetun control server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ services:
     container_name: glueforward
     environment:
       GLUETUN_URL: "..."
+      GLUETUN_API_KEY: "..."
       QBITTORRENT_URL: "..."
       QBITTORRENT_USERNAME: "..."
       QBITTORRENT_PASSWORD: "..."
@@ -43,6 +44,12 @@ services:
     <td>GLUETUN_URL</td>
     <td>Url to the <a href="https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#openvpn-and-wireguard">gluetun control server</a></td>
     <td>No</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>GLUETUN_API_KEY</td>
+    <td>Your gluetun control server <a href="https://github.com/t-anc/GSP-Qbittorent-Gluetun-sync-port-mod#gluetun">API key</a></td>
+    <td>Yes (only for gluetun up to v3.4.0)</td>
     <td></td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ services:
   </tr>
   <tr>
     <td>GLUETUN_API_KEY</td>
-    <td>Your gluetun control server <a href="https://github.com/t-anc/GSP-Qbittorent-Gluetun-sync-port-mod#gluetun">API key</a></td>
+    <td>Your gluetun control server <a href="https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md">API key</a></td>
     <td>Yes (only for gluetun up to v3.4.0)</td>
     <td></td>
   </tr>

--- a/glueforward/gluetun.py
+++ b/glueforward/gluetun.py
@@ -34,7 +34,7 @@ class _PortForwardedResponseModel(TypedDict):
 class GluetunClient:
 
     __client: httpx.Client
-    __credentials: dict[str, str]
+    __api_key: str
 
     def __init__(self, url: str, api_key: str = ''):
         self.__api_key = api_key

--- a/glueforward/gluetun.py
+++ b/glueforward/gluetun.py
@@ -1,9 +1,16 @@
 import logging
-from typing import TypedDict
+from typing import TypedDict, Union
 
 import httpx
 
-from errors import RetryableGlueforwardError
+from errors import GlueforwardError, RetryableGlueforwardError
+
+
+class GluetunAuthFailed(GlueforwardError):
+    """Exception raised when gluetun authentication fails"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args, message="Failed to authenticate to Gluetun. See https://github.com/t-anc/GSP-Qbittorent-Gluetun-sync-port-mod#gluetun")
 
 
 class GluetunUnreachable(RetryableGlueforwardError):
@@ -27,15 +34,27 @@ class _PortForwardedResponseModel(TypedDict):
 class GluetunClient:
 
     __client: httpx.Client
+    __credentials: dict[str, str]
 
-    def __init__(self, url: str):
+    def __init__(self, url: str, api_key: str = ''):
+        self.__api_key = api_key
         self.__client = httpx.Client(base_url=url)
         logging.debug("Gluetun client created with base url %s", url)
 
+    def get_has_credentials(self) -> bool:
+        return len(self.__api_key) > 0
+
     def get_forwarded_port(self) -> int:
+
         try:
-            response = self.__client.get(url="/v1/openvpn/portforwarded")
+            if self.get_has_credentials():
+                response = self.__client.request(method='GET', url="/v1/openvpn/portforwarded", headers=f"X-API-Key:{self.__api_key}")
+            else:
+                response = self.__client.request(method='GET', url="/v1/openvpn/portforwarded")
+            if response.status_code == 401:
+                raise GluetunAuthFailed()
             response.raise_for_status()
+
         except httpx.ConnectError as exception:
             raise GluetunUnreachable(self.__client.base_url) from exception
         except httpx.HTTPStatusError as exception:

--- a/glueforward/gluetun.py
+++ b/glueforward/gluetun.py
@@ -10,7 +10,7 @@ class GluetunAuthFailed(GlueforwardError):
     """Exception raised when gluetun authentication fails"""
 
     def __init__(self, *args: object) -> None:
-        super().__init__(*args, message="Failed to authenticate to Gluetun. See https://github.com/t-anc/GSP-Qbittorent-Gluetun-sync-port-mod#gluetun")
+        super().__init__(*args, message="Failed to authenticate to Gluetun. See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md")
 
 
 class GluetunUnreachable(RetryableGlueforwardError):

--- a/glueforward/gluetun.py
+++ b/glueforward/gluetun.py
@@ -48,7 +48,7 @@ class GluetunClient:
 
         try:
             if self.get_has_credentials():
-                response = self.__client.request(method='GET', url="/v1/openvpn/portforwarded", headers=f"X-API-Key:{self.__api_key}")
+                response = self.__client.request(method='GET', url="/v1/openvpn/portforwarded", headers={"X-API-Key": self.__api_key})
             else:
                 response = self.__client.request(method='GET', url="/v1/openvpn/portforwarded")
             if response.status_code == 401:

--- a/glueforward/main.py
+++ b/glueforward/main.py
@@ -23,14 +23,14 @@ class Application:
     __success_interval: int
     __retry_interval: int
 
-    def __mgetreqenv(self, name: str) -> str:
+    def __required_getenv(self, name: str) -> str:
         """Get an environment variable or exit if it is not set"""
         if (value := getenv(name)) is None:
             logging.critical("Environment variable %s is required", name)
             sys.exit(ReturnCodes.MISSING_ENVIRONMENT_VARIABLE)
         return value
 
-    def __mgetoptenv(self, name: str) -> Union[None, str]:
+    def __optional_getenv(self, name: str) -> Union[None, str]:
         """Get an environment variable or warn if it is not set"""
         if (value := getenv(name)) is None:
             logging.warning("Environment variable %s is not defined", name)
@@ -73,14 +73,14 @@ class Application:
         self.__retry_interval = int(getenv("RETRY_INTERVAL", str(10)))
         self.__success_interval = int(getenv("SUCCESS_INTERVAL", str(60 * 5)))
         self.__gluetun = GluetunClient(
-            url=self.__mgetreqenv("GLUETUN_URL"),
-            api_key=self.__mgetoptenv("GLUETUN_API_KEY")
+            url=self.__required_getenv("GLUETUN_URL"),
+            api_key=self.__optional_getenv("GLUETUN_API_KEY")
         )
         self.__qbittorrent = QBittorrentClient(
-            url=self.__mgetreqenv("QBITTORRENT_URL"),
+            url=self.__required_getenv("QBITTORRENT_URL"),
             credentials={
-                "username": self.__mgetreqenv("QBITTORRENT_USERNAME"),
-                "password": self.__mgetreqenv("QBITTORRENT_PASSWORD"),
+                "username": self.__required_getenv("QBITTORRENT_USERNAME"),
+                "password": self.__required_getenv("QBITTORRENT_PASSWORD"),
             },
         )
 

--- a/glueforward/main.py
+++ b/glueforward/main.py
@@ -1,7 +1,6 @@
 import logging
 import logging.config as logging_config
 import sys
-from typing import Union
 from enum import IntEnum
 from os import getenv
 from time import sleep
@@ -30,7 +29,7 @@ class Application:
             sys.exit(ReturnCodes.MISSING_ENVIRONMENT_VARIABLE)
         return value
 
-    def __optional_getenv(self, name: str) -> Union[None, str]:
+    def __optional_getenv(self, name: str) -> None | str:
         """Get an environment variable or warn if it is not set"""
         if (value := getenv(name)) is None:
             logging.warning("Environment variable %s is not defined", name)


### PR DESCRIPTION
Hey hey,

As mentioned [in the docs](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md), gluetun v3.40.0 introduced support for authentication to the control server.

While it is still optional for retrocompatibility, authentication will become required for releases after (current) v3.4.0

Cheers :)