### PR TITLE
feat: Add slskd support to glueforward

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # glueforward
 
-Updates qbittorrent's listening port to be gluetun's forwarded port on the VPN side.
+Updates application listening ports to match gluetun's forwarded port on the VPN side.
+Supports qBittorrent and slskd via their respective APIs.
 
 The goal is to no longer query a file for the exposed port status, but instead use gluetun's API. This is in preparation for the [deprecation of the file approach in a future version of gluetun](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/vpn-port-forwarding.md#native-integrations).
 
@@ -9,6 +10,7 @@ The goal is to no longer query a file for the exposed port status, but instead u
 The recommended way to use glueforward is with docker compose.
 
 ```yml
+# For qBittorrent:
 services:
   glueforward:
     image: ghcr.io/geoffreycoulaud/glueforward:latest
@@ -16,6 +18,7 @@ services:
     environment:
       GLUETUN_URL: "..."
       GLUETUN_API_KEY: "..."
+      SERVICE_TYPE: "qbittorrent"
       QBITTORRENT_URL: "..."
       QBITTORRENT_USERNAME: "..."
       QBITTORRENT_PASSWORD: "..."
@@ -26,6 +29,26 @@ services:
     # Insert gluetun service definition here
   qbittorrent:
     # Insert qbittorrent service definition here
+
+# For slskd:
+services:
+  glueforward:
+    image: ghcr.io/geoffreycoulaud/glueforward:latest
+    container_name: glueforward
+    environment:
+      GLUETUN_URL: "..."
+      GLUETUN_API_KEY: "..."
+      SERVICE_TYPE: "slskd"
+      SLSKD_URL: "..."
+      SLSKD_USERNAME: "..."
+      SLSKD_PASSWORD: "..."
+    depends_on:
+      - gluetun
+      - slskd
+  gluetun:
+    # Insert gluetun service definition here
+  slskd:
+    # Insert slskd service definition here
 ```
 
 ## Environment variables
@@ -53,21 +76,45 @@ services:
     <td></td>
   </tr>
   <tr>
+    <td>SERVICE_TYPE</td>
+    <td>Service to configure (qbittorrent or slskd)</td>
+    <td>Yes</td>
+    <td>qbittorrent</td>
+  </tr>
+  <tr>
     <td>QBITTORRENT_URL</td>
     <td>Url to the qbittorrent web UI</td>
-    <td>No</td>
+    <td>Yes²</td>
     <td></td>
   </tr>
   <tr>
     <td>QBITTORRENT_USERNAME</td>
     <td>Username to authenticate to qbittorrent</td>
-    <td>No</td>
+    <td>Yes²</td>
     <td></td>
   </tr>
   <tr>
     <td>QBITTORRENT_PASSWORD</td>
     <td>Password to authenticate to qbittorrent</td>
-    <td>No</td>
+    <td>Yes²</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>SLSKD_URL</td>
+    <td>Url to the slskd API</td>
+    <td>Yes³</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>SLSKD_USERNAME</td>
+    <td>Username to authenticate to slskd</td>
+    <td>Yes³</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>SLSKD_PASSWORD</td>
+    <td>Password to authenticate to slskd</td>
+    <td>Yes³</td>
     <td></td>
   </tr>
   <tr>
@@ -100,9 +147,13 @@ services:
 </table>
 
 1. Optional before gluetun v3.40.0, where all control server routes become private by default
+2. Required when SERVICE_TYPE=qbittorrent
+3. Required when SERVICE_TYPE=slskd
 
 ## Other info
 
-- Ensure that gluetun and qbittorrent are reachable from glueforward.  
+- Ensure that gluetun and your service (qbittorrent/slskd) are reachable from glueforward.  
 For example: If you separate services in different networks, make sure glueforward has access to the appropriate ones.
+- Service types are mutually exclusive (only one service per container instance). For multiple services, run separate containers with different SERVICE_TYPE values.
+- For slskd support, remote configuration must be enabled (see [slskd docs](https://github.com/slskd/slskd/blob/master/docs/config.md))
 - [Gluetun wiki - VPN server port forwarding](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/vpn-port-forwarding.md)

--- a/glueforward/service_client.py
+++ b/glueforward/service_client.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+import httpx
+
+class ServiceClient(ABC):
+    """Abstract base class for service clients that handle port configuration"""
+
+    @abstractmethod
+    def set_port(self, port: int) -> None:
+        """Update the service's listening port
+
+        Args:
+            port: The port number to set (1024-65535)
+        """
+
+    def _handle_request_exception(self, exception: httpx.HTTPStatusError,
+                               auth_error_class: type,
+                               unreachable_error_class: type) -> None:
+        """Shared exception handler for service client requests
+
+        Args:
+            exception: The HTTPStatusError that occurred
+            auth_error_class: Exception class to raise for auth errors (401/403)
+            unreachable_error_class: Exception class to raise for 5xx errors
+        """
+        if exception.response.status_code in (401, 403):
+            raise auth_error_class(
+                exception.response.status_code,
+                exception.response.text
+            ) from exception
+        if exception.response.status_code // 100 == 5:
+            raise unreachable_error_class(
+                exception.response.status_code,
+                exception.response.text
+            ) from exception
+        raise exception

--- a/glueforward/slskd.py
+++ b/glueforward/slskd.py
@@ -1,0 +1,155 @@
+import json
+import logging
+from typing import Optional
+from io import StringIO
+import httpx
+from ruamel.yaml import YAML
+
+from errors import GlueforwardError, RetryableGlueforwardError
+from service_client import ServiceClient
+
+
+class SlskdAuthFailed(GlueforwardError):
+    """Exception raised when slskd authentication fails"""
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args, message="Failed to authenticate to slskd")
+
+
+class SlskdSetPortFailed(RetryableGlueforwardError):
+    """Exception raised when slskd port setting fails"""
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args, message="Failed to set slskd listening port")
+
+
+class SlskdUnreachable(RetryableGlueforwardError):
+    """Exception raised when slskd is unreachable"""
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args, message="Failed to reach slskd")
+
+
+class SlskdReauthNeeded(RetryableGlueforwardError):
+    """Exception raised when slskd needs reauthentication"""
+    def __init__(self, *args: object) -> None:
+        super().__init__(
+            *args,
+            message="slskd needs reauthentication",
+            retry_immediately=True,
+        )
+
+
+class SlskdIllegalPort(RetryableGlueforwardError):
+    """Exception raised when an invalid port is provided"""
+    def __init__(self, port: int, *args: object) -> None:
+        super().__init__(
+            *args,
+            message=f"Invalid port {port} - must be between 1024 and 65535",
+            retry_immediately=False,
+        )
+
+
+class SlskdClient(ServiceClient):
+    __client: httpx.Client
+    __credentials: dict[str, str]
+    __token: Optional[str] = None
+    __yaml: YAML
+
+    def __init__(self, url: str, credentials: dict[str, str]):
+        self.__credentials = credentials
+        self.__client = httpx.Client(base_url=url)
+        # Configure YAML parser
+        self.__yaml = YAML()
+        self.__yaml.preserve_quotes = True
+        self.__yaml.indent(mapping=2, sequence=4, offset=2)
+        logging.debug("slskd client created with base url %s", url)
+
+    def get_is_authenticated(self) -> bool:
+        return self.__token is not None
+
+    def __request(self, method: str, url: str, **kwargs) -> Optional[httpx.Response]:
+        """Send authenticated request to slskd API"""
+        headers = kwargs.pop('headers', {})
+        if self.get_is_authenticated():
+            headers['Authorization'] = f"Bearer {self.__token}"
+
+        try:
+            response = self.__client.request(
+                method=method,
+                url=url,
+                headers=headers,
+                **kwargs
+            )
+            response.raise_for_status()
+            return response
+        except (httpx.ConnectError, httpx.ReadTimeout) as exception:
+            raise SlskdUnreachable(self.__client.base_url) from exception
+        except httpx.HTTPStatusError as exception:
+            self._handle_request_exception(
+                exception,
+                SlskdAuthFailed,
+                SlskdSetPortFailed
+            )
+            return None
+
+    def authenticate(self) -> None:
+        if self.get_is_authenticated():
+            return
+        logging.debug("Authenticating to slskd")
+        response = self.__request(
+            method="post",
+            url="/api/v0/session",
+            json=self.__credentials
+        )
+        self.__token = response.json().get('token')
+        logging.debug("slskd client authenticated")
+
+    def reset_authentication(self) -> None:
+        self.__token = None
+        logging.debug("slskd client authentication reset")
+
+    def __get_current_config(self) -> dict:
+        """Get current YAML config from slskd"""
+        response = self.__request(method="get", url="/api/v0/options/yaml")
+        try:
+            response_json = response.json()
+            if isinstance(response_json, str):
+                return self.__yaml.load(response_json) or {}
+            return self.__yaml.load(response_json.get('yaml', '')) or {}
+        except ValueError:
+            return self.__yaml.load(response.text) or {}
+
+    def __update_config(self, config: dict) -> None:
+        """Update slskd config with new YAML"""
+        # Convert config to YAML string using StringIO stream
+        # ruamel.yaml requires a stream to properly handle formatting/indentation
+        stream = StringIO()
+        self.__yaml.dump(config, stream)
+        yaml_content = stream.getvalue()
+
+        # The slskd API expects a JSON payload containing the YAML as a string property
+        # json.dumps() ensures proper string escaping for the JSON payload
+        self.__request(
+            method="post",
+            url="/api/v0/options/yaml",
+            data=json.dumps(yaml_content),
+            headers={"Content-Type": "application/json"}
+        )
+
+    def set_port(self, port: int) -> None:
+        """Update the listening port in slskd config via API"""
+        if not 1024 <= port <= 65535:
+            raise SlskdIllegalPort(port)
+
+        if not self.get_is_authenticated():
+            self.authenticate()
+
+        try:
+            config = self.__get_current_config()
+            if 'soulseek' not in config:
+                config['soulseek'] = {}
+            config['soulseek']['listen_port'] = port
+            self.__update_config(config)
+        except SlskdAuthFailed as exc:
+            self.reset_authentication()
+            raise SlskdReauthNeeded() from exc
+        except httpx.HTTPStatusError as e:
+            raise SlskdSetPortFailed("Failed to update port") from e

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 httpx>=0.27.0
+ruamel.yaml>=0.17.0


### PR DESCRIPTION
## Description
See: https://github.com/slskd/slskd/issues/1011

This PR adds support for slskd to glueforward, allowing it to manage port forwarding for Soulseek clients through gluetun. The changes include:

- Added SlskdClient class for config file management
- Modified main application to support multiple service types
- Updated README with slskd documentation

## Configuration Notes
- Service types (qbittorrent/slskd) are mutually exclusive - only one can be configured per glueforward instance
- For multiple services, run separate containers with different SERVICE_TYPE values
- qBittorrent is the default service type, so existing configurations do not need to be edited

## Testing
- Tested with two parallel instances:
  - One configured for qBittorrent (existing functionality)
  - One configured for slskd (new functionality)
- Both instances working as intended with proper port forwarding
- Passed pylint with no issues

<details>
<summary>Click to view test screenshots</summary>

![glueforward-slskd logs](https://github.com/user-attachments/assets/e74c1c53-7d79-49fa-a928-4d2720b487c1)
![slskd Options Webpage](https://github.com/user-attachments/assets/16161963-0a18-442d-ba0a-7c1edf23fa41)

</details>

## Documentation
Updated README.md to include:
- slskd docker-compose example
- SERVICE_TYPE and SLSKD_CONFIG_PATH environment variables
- Note about required volume mount for slskd.yaml

## Other Notes
This is my first real PR, so I apologize if any mistakes were made! Please feel free to give feedback and let me know if anything needs changed/improved. Thanks! :)
