### PR TITLE
Updated API endpoint to reflect recent change in Gluetun

### DIFF
--- a/glueforward/gluetun.py
+++ b/glueforward/gluetun.py
@@ -50,7 +50,7 @@ class GluetunClient:
 
     def get_forwarded_port(self) -> int:
         try:
-            response = self.__client.get(url="/v1/openvpn/portforwarded")
+            response = self.__client.get(url="/v1/portforward")
             response.raise_for_status()
         except (httpx.ConnectError, httpx.ReadTimeout) as exception:
             raise GluetunUnreachable(self.__client.base_url) from exception


### PR DESCRIPTION
Gluetun apparently recently canged the API endpoint for the port forward from `/v1/openvpn/portforwarded` to `/v1/portforward`.

I couldn't find any mention of this in their Wiki, but the control server was nice enough to give us the new endpoint.

All working again with this tiny change.

PS: Don't forget to update your gluetun control server settings `toml` file to allow authentication on the correct endpoint :)