### PR TITLE
ci: gate merges on end-to-end tests, safely for forks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,15 @@ name: Run checks
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out. Defaults to whatever triggered the calling workflow."
+        type: string
+        default: ""
+      cache-write:
+        description: "Whether this run may populate the shared uv cache. Trusted callers only."
+        type: boolean
+        default: false
 
 jobs:
 
@@ -10,10 +19,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          save-cache: ${{ inputs.cache-write }}
       - name: Install dependencies
         run: uv sync --frozen
       - name: Run pylint
@@ -24,10 +37,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          save-cache: ${{ inputs.cache-write }}
       - name: Install dependencies
         run: uv sync --frozen
       - name: Run pyright
@@ -38,10 +55,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          save-cache: ${{ inputs.cache-write }}
       - name: Install dependencies
         run: uv sync --frozen
       - name: Run tests

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,0 +1,65 @@
+name: Run end-to-end tests
+
+on:
+  workflow_call:
+    inputs:
+      environment-name:
+        description: "GitHub Environment gating this job. Untrusted code must get one with required reviewers."
+        type: string
+        required: true
+      ref:
+        description: "Git ref to check out. Defaults to whatever triggered the calling workflow."
+        type: string
+        default: ""
+      cache-write:
+        description: "Whether this run may populate the shared Buildx cache. Trusted callers only."
+        type: boolean
+        default: false
+    secrets:
+      wireguard-private-key:
+        required: true
+
+jobs:
+
+  e2e:
+    name: End-to-end tests
+    environment: ${{ inputs.environment-name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    # One WireGuard key means one VPN connection at a time. Every caller shares
+    # this group, and a run waits its turn instead of cancelling the holder.
+    concurrency:
+      group: protonvpn-wireguard-key
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # The tests shell out to `docker buildx build` themselves, so the cache
+      # credentials docker/build-push-action would have injected on its own
+      # have to be exported into the environment by hand.
+      - name: Expose GitHub Actions cache to Buildx
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      # Uses a real ProtonVPN key: never log it.
+      - name: Run end-to-end tests
+        run: uv run pytest glueforward/tests/end_to_end -o addopts=""
+        env:
+          WIREGUARD_PRIVATE_KEY: ${{ secrets.wireguard-private-key }}
+          E2E_CACHE_WRITE: ${{ inputs.cache-write }}

--- a/.github/workflows/main-pr.yml
+++ b/.github/workflows/main-pr.yml
@@ -1,11 +1,49 @@
 name: Checks for pull requests towards main branch
 
+# Runs on pull_request_target, not pull_request, because only that event gives
+# a pull request from a fork access to the real ProtonVPN key the end-to-end
+# tests need. Both jobs below check out the pull request's own head, so both
+# run the contributor's code:
+#   - check gets no secrets, a read-only token and no cache writes, so an
+#     untrusted run there can do no more than burn CI minutes;
+#   - e2e-tests gets the key, and for a fork the required reviewers on the
+#     e2e-fork-approval environment are the ONLY barrier in front of it.
+# See CONTRIBUTING.md before approving one.
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - "main"
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
 
 jobs:
 
   check:
+    permissions:
+      contents: read
     uses: ./.github/workflows/check.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  e2e-tests:
+    needs: check
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    # Superseded runs of the same pull request give up the VPN key rather than
+    # sit in front of the newer commit in the queue below.
+    concurrency:
+      group: e2e-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/end-to-end-tests.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      # Branches pushed to this repository already imply write access, so they
+      # run unattended. Anything else waits for a maintainer to approve it.
+      environment-name: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'e2e' || 'e2e-fork-approval' }}
+      # cache-write stays off for both jobs: under pull_request_target the
+      # caches are scoped to the default branch, so no pull request may write
+      # to what main later reads.
+    secrets:
+      wireguard-private-key: ${{ secrets.PROTONVPN_WIREGUARD_PRIVATE_KEY }}

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -16,13 +16,26 @@ env:
 jobs:
 
   check:
+    permissions:
+      contents: read
     uses: ./.github/workflows/check.yml
+    with:
+      cache-write: true
+
+  e2e-tests:
+    needs: check
+    uses: ./.github/workflows/end-to-end-tests.yml
+    with:
+      environment-name: e2e
+      cache-write: true
+    secrets:
+      wireguard-private-key: ${{ secrets.PROTONVPN_WIREGUARD_PRIVATE_KEY }}
 
   build-and-push-image:
     runs-on: ubuntu-latest
 
-    #  Ensure that the code passes checks before building and pushing the image
-    needs: check
+    #  Ensure that the code passes checks and end-to-end tests before building and pushing the image
+    needs: [check, e2e-tests]
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
@@ -61,26 +74,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync --frozen
-
-      # Builds the image with Buildx (loaded into the local daemon, not pushed) and
-      # runs it against a real gluetun/ProtonVPN and a real qBittorrent. Reuses this
-      # job's Buildx cache, so the final multi-arch build below only has the arm64
-      # layers left to do. Requires a real, short-lived ProtonVPN secret: never log it.
-      - name: Run end-to-end tests
-        run: uv run pytest glueforward/tests/end_to_end -o addopts=""
-        env:
-          WIREGUARD_PRIVATE_KEY: ${{ secrets.PROTONVPN_WIREGUARD_PRIVATE_KEY }}
-
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      # Builds and pushes the multi-arch image. Reads/writes the same GitHub
+      # Actions cache the e2e-tests job populated, so only the layers that job
+      # didn't already build (arm64) need building here.
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
@@ -90,6 +86,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
       - name: Generate artifact attestation
@@ -99,7 +97,7 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-  # If a tag is pushed, also create a draft release
+  # If a tag is pushed, also create a draft release
   create-draft-release:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@ dist/
 .mypy_cache
 .pytest_cache
 
+# Scratch workspace for agentic coding workflows (plans, ledgers, review
+# packages); never meant to be committed.
+.superpowers/
+
 # Local secrets for running end-to-end tests (see CONTRIBUTING.md); never commit this.
 .env.e2e.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,12 @@ The `-o addopts=""` resets the coverage flags from `pyproject.toml`: they target
 
 Without `WIREGUARD_PRIVATE_KEY` set, these tests are skipped automatically, and a plain `uv run pytest` never runs them (they're outside `testpaths`). Expect a real run to take a minute or two: it builds an image and negotiates a real VPN connection.
 
+## Approving end-to-end tests on a fork pull request
+
+The end-to-end tests need the real ProtonVPN key from above, so on a pull request from a fork they wait for a maintainer to approve the run (`main-pr.yml`, gated by the `e2e-fork-approval` environment). Pull requests from a branch of this repository run them unattended.
+
+That approval is the *only* barrier between the fork's code and the key. Before clicking Approve, read the whole diff rather than just the application code. The `Dockerfile`, `conftest.py`, `pyproject.toml` and `uv.lock` all run with the secret in scope too.
+
 ## Lint
 
 ```sh

--- a/glueforward/tests/end_to_end/conftest.py
+++ b/glueforward/tests/end_to_end/conftest.py
@@ -154,10 +154,16 @@ def glueforward_image():
     BuildKit's cache with the Buildx-based CI build/push steps).
     """
     tag = "glueforward:e2e"
-    subprocess.run(
-        ["docker", "buildx", "build", "--load", "-t", tag, str(REPO_ROOT)],
-        check=True,
-    )
+    command = ["docker", "buildx", "build", "--load"]
+    # The GitHub Actions cache only exists inside a workflow run. Reads are
+    # always safe there; writes are opt-in because the cache is shared with
+    # the default branch, and untrusted code must never populate it.
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        command += ["--cache-from", "type=gha"]
+        if os.environ.get("E2E_CACHE_WRITE") == "true":
+            command += ["--cache-to", "type=gha,mode=max,ignore-error=true"]
+    command += ["-t", tag, str(REPO_ROOT)]
+    subprocess.run(command, check=True)
     return tag
 
 


### PR DESCRIPTION
## What

Makes a passing end-to-end run a condition for merging, without handing the ProtonVPN key to anyone who opens a pull request.

- Pull requests from a branch of this repository run the end-to-end tests unattended.
- Pull requests from a fork run them only once a maintainer approves the run.
- `main` now requires `check / pylint`, `check / pyright`, `check / pytest` and `e2e-tests / End-to-end tests`.

## How

`main-pr.yml` moves to `pull_request_target`, because that is the only event giving a fork's pull request access to repository secrets. Both of its jobs check out the pull request's own head, so both run contributor code:

| Job | What it can reach |
| --- | --- |
| `check` | No secrets, a read-only token, no cache writes. An untrusted run there can do no more than spend CI minutes. |
| `e2e-tests` | The real key, behind a GitHub Environment. |

Which environment is picked from the head repository: `e2e` (no protection rules) for a branch of this repository, `e2e-fork-approval` (required reviewers) for anything else. That approval is the only barrier in front of the key, so CONTRIBUTING.md now spells out what to read before clicking it.

The end-to-end job also joins a repository-wide concurrency group. One WireGuard key means one VPN connection at a time, so a run waits its turn instead of cancelling whichever run holds the key.

Cache writes stay opt-in in both reusable workflows. Under `pull_request_target` the uv and Buildx caches are scoped to the default branch, so only pushes to `main` may populate what `main` later reads.

## Note on verification

`main-pr.yml` cannot run on this pull request. A `pull_request_target` workflow is always read from the default branch, so its new form only takes effect once merged, and the first pull request opened afterwards is what exercises it.

Checked so far: actionlint on all four workflows, plus the checks and the end-to-end suite locally.
