### PR TITLE
refactor: make the internals protected rather than name-mangled

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,11 +41,8 @@ jobs:
           save-cache: ${{ inputs.cache-write }}
       - name: Install dependencies
         run: uv sync --frozen
-      - name: Run pylint on the application
-        run: uv run pylint glueforward/main
-      # Separate run: linted together, the tests raise an unsuppressable invalid-name.
-      - name: Run pylint on the tests
-        run: uv run pylint glueforward/tests
+      - name: Run pylint
+        run: uv run pylint glueforward
 
   pyright:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,9 @@ That approval is the *only* barrier between the fork's code and the key. Before 
 ## Lint
 
 ```sh
-uv run pylint glueforward/main
-uv run pylint glueforward/tests
+uv run pylint glueforward
 uv run pyright glueforward
 docker run --rm -v "$(pwd):/repo" --workdir /repo rhysd/actionlint:1.7.7
 ```
 
-Both linters cover the tests as well as the application. pylint takes two runs rather than one over `glueforward`: the unit tests assign name-mangled attributes, and pylint judges those names in the scope of the class that owns them rather than the file they appear in, so linting the application alongside them reports violations that nothing in a test file can suppress.
+Both linters cover the tests as well as the application.

--- a/glueforward/main/errors.py
+++ b/glueforward/main/errors.py
@@ -1,8 +1,6 @@
 class RetryableError(Exception):
     """Exception raised when a retryable error occurs"""
 
-    __retry_immediately: bool
-
     def __init__(
         self,
         *args: object,
@@ -10,7 +8,7 @@ class RetryableError(Exception):
         retry_immediately: bool = False,
     ) -> None:
         super().__init__(*args, message)
-        self.__retry_immediately = retry_immediately
+        self._retry_immediately = retry_immediately
 
     def get_retry_immediately(self) -> bool:
-        return self.__retry_immediately
+        return self._retry_immediately

--- a/glueforward/main/gluetun.py
+++ b/glueforward/main/gluetun.py
@@ -35,20 +35,20 @@ class _PortForwardedResponseModel(TypedDict):
 
 
 class GluetunClient:
-    __client: httpx.Client
+    _client: httpx.Client
 
     def __init__(self, url: str, api_key: None | str):
-        self.__client = httpx.Client(base_url=url)
+        self._client = httpx.Client(base_url=url)
         if api_key:
-            self.__client.headers.update({"X-API-Key": api_key})
+            self._client.headers.update({"X-API-Key": api_key})
         logging.debug("Gluetun client created with base url %s", url)
 
     def get_forwarded_port(self) -> int:
         try:
-            response = self.__client.get(url="/v1/portforward")
+            response = self._client.get(url="/v1/portforward")
             response.raise_for_status()
         except (httpx.ConnectError, httpx.ReadTimeout) as exception:
-            raise GluetunUnreachable(self.__client.base_url) from exception
+            raise GluetunUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
             if exception.response.status_code == 401:
                 raise GluetunAuthFailed(exception.response.text) from exception

--- a/glueforward/main/main.py
+++ b/glueforward/main/main.py
@@ -18,26 +18,33 @@ class ReturnCodes(IntEnum):
 
 class Application:
 
-    __gluetun: GluetunClient
-    __service_client: ServiceClient
-    __success_interval: int
-    __retry_interval: int
+    def __init__(self) -> None:
+        self._configure_logging()
+        self._retry_interval = int(getenv("RETRY_INTERVAL", str(10)))
+        self._success_interval = int(getenv("SUCCESS_INTERVAL", str(60 * 5)))
+        self._gluetun = GluetunClient(
+            url=self._required_getenv("GLUETUN_URL"),
+            api_key=getenv("GLUETUN_API_KEY"),
+        )
+        self._service_client = self._create_service_client(
+            service_type=self._required_getenv("SERVICE_TYPE")
+        )
 
-    def __required_getenv(self, name: str) -> str:
+    def _required_getenv(self, name: str) -> str:
         """Get an environment variable or exit if it is not set"""
         if (value := getenv(name)) is None:
             logging.critical("Environment variable %s is required", name)
             sys.exit(ReturnCodes.MISSING_ENVIRONMENT_VARIABLE)
         return value
 
-    def __create_service_client(self, service_type: str) -> ServiceClient:
+    def _create_service_client(self, service_type: str) -> ServiceClient:
         """Create and return the appropriate service client based on SERVICE_TYPE"""
         if service_type == "qbittorrent":
             return QBittorrentClient(
-                url=self.__required_getenv("QBITTORRENT_URL"),
+                url=self._required_getenv("QBITTORRENT_URL"),
                 credentials={
-                    "username": self.__required_getenv("QBITTORRENT_USERNAME"),
-                    "password": self.__required_getenv("QBITTORRENT_PASSWORD"),
+                    "username": self._required_getenv("QBITTORRENT_USERNAME"),
+                    "password": self._required_getenv("QBITTORRENT_PASSWORD"),
                 },
             )
         logging.critical(
@@ -46,10 +53,9 @@ class Application:
         )
         sys.exit(ReturnCodes.UNKNOWN_SERVICE_TYPE)
 
-    def _setup(self) -> None:
-        """Setup the application"""
-
-        # Configure logging
+    @staticmethod
+    def _configure_logging() -> None:
+        """Configure logging from the LOG_LEVEL environment variable"""
         log_level = (
             environment_log_level
             if (environment_log_level := getenv("LOG_LEVEL"))
@@ -79,36 +85,24 @@ class Application:
             level=log_level, format="%(asctime)s [%(levelname)s] %(message)s"
         )
 
-        # Initialize the state
-        self.__retry_interval = int(getenv("RETRY_INTERVAL", str(10)))
-        self.__success_interval = int(getenv("SUCCESS_INTERVAL", str(60 * 5)))
-        self.__gluetun = GluetunClient(
-            url=self.__required_getenv("GLUETUN_URL"),
-            api_key=getenv("GLUETUN_API_KEY"),
-        )
-        self.__service_client = self.__create_service_client(
-            service_type=self.__required_getenv("SERVICE_TYPE")
-        )
-
-    def __loop(self) -> None:
+    def _loop(self) -> None:
         """Function called in a loop to check for changes in the forwarded port"""
-        forwarded_port = self.__gluetun.get_forwarded_port()
-        self.__service_client.set_port(forwarded_port)
+        forwarded_port = self._gluetun.get_forwarded_port()
+        self._service_client.set_port(forwarded_port)
         logging.info("Listening port set to %d", forwarded_port)
 
     def run(self) -> None:
-        """App entry point, in charge of setting up the app and starting the loop"""
-        self._setup()
+        """App entry point, in charge of starting the loop"""
         while True:
             try:
-                self.__loop()
+                self._loop()
             except RetryableError as error:
                 logging.error("Retryable error in lifecycle", exc_info=error)
                 if error.get_retry_immediately():
                     logging.info("Retrying immediately")
                 else:
-                    logging.info("Retrying in %d seconds", self.__retry_interval)
-                    sleep(self.__retry_interval)
+                    logging.info("Retrying in %d seconds", self._retry_interval)
+                    sleep(self._retry_interval)
             except Exception as error:  # pylint: disable=broad-exception-caught
                 logging.critical(
                     "Unretryable error in lifecycle, shutting down",
@@ -116,7 +110,7 @@ class Application:
                 )
                 sys.exit(ReturnCodes.UNRETRYABLE_EXCEPTION_IN_LIFECYCLE)
             else:
-                sleep(self.__success_interval)
+                sleep(self._success_interval)
 
 
 def main() -> None:

--- a/glueforward/main/qbittorrent.py
+++ b/glueforward/main/qbittorrent.py
@@ -45,56 +45,56 @@ class QBittorrentAuthenticationNeeded(RetryableError):
 
 class QBittorrentClient(ServiceClient):
 
-    __client: httpx.Client
-    __credentials: dict[str, str]
+    _client: httpx.Client
+    _credentials: dict[str, str]
 
     def __init__(self, url: str, credentials: dict[str, str]):
-        self.__credentials = credentials
-        self.__client = httpx.Client(base_url=url)
+        self._credentials = credentials
+        self._client = httpx.Client(base_url=url)
         logging.debug("qBittorrent client created with base url %s", url)
 
-    def __get_is_authenticated(self) -> bool:
-        return len(self.__client.cookies) > 0
+    def _get_is_authenticated(self) -> bool:
+        return len(self._client.cookies) > 0
 
-    def __authenticate(self) -> None:
+    def _authenticate(self) -> None:
         logging.debug("Authenticating to qBittorrent")
         try:
-            response = self.__client.post(
+            response = self._client.post(
                 url="/api/v2/auth/login",
-                data=self.__credentials,
+                data=self._credentials,
             )
             response.raise_for_status()
         except (httpx.ConnectError, httpx.ReadTimeout) as exception:
-            raise QBittorrentUnreachable(self.__client.base_url) from exception
+            raise QBittorrentUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
             if exception.response.status_code == 403:
                 raise QBittorrentForbiddenError from exception
             raise QBittorrentServerError from exception
-        self.__client.cookies.update(response.cookies)
+        self._client.cookies.update(response.cookies)
         logging.debug("qBittorrent client authenticated")
 
-    def __reset_authentication(self) -> None:
-        self.__client.cookies.clear()
+    def _reset_authentication(self) -> None:
+        self._client.cookies.clear()
         logging.debug("qBittorrent client authentication reset")
 
     def set_port(self, port: int) -> None:
-        if not self.__get_is_authenticated():
-            self.__authenticate()
+        if not self._get_is_authenticated():
+            self._authenticate()
         data = {"listen_port": port, "random_port": False, "upnp": False}
         try:
-            response = self.__client.post(
+            response = self._client.post(
                 url="/api/v2/app/setPreferences",
                 data={"json": json.dumps(data)},
             )
             response.raise_for_status()
         except (httpx.ConnectError, httpx.ReadTimeout) as exception:
-            raise QBittorrentUnreachable(self.__client.base_url) from exception
+            raise QBittorrentUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
             if exception.response.status_code == 401:
                 # If failed here, we were authenticated before but the session expired,
                 # so we need to reauthenticate and retry.
                 logging.warning("qBittorrent session expired")
-                self.__reset_authentication()
+                self._reset_authentication()
                 raise QBittorrentAuthenticationNeeded from exception
             raise exception
         logging.info("Successfully set qBittorrent port")

--- a/glueforward/tests/unit/test_main.py
+++ b/glueforward/tests/unit/test_main.py
@@ -2,7 +2,6 @@
 
 # Asserts on Application's internals, which have no public accessor.
 # pylint: disable=protected-access
-# pyright: reportAttributeAccessIssue=false
 
 from unittest.mock import MagicMock
 
@@ -13,7 +12,7 @@ from glueforward.main.gluetun import GluetunClient
 from glueforward.main.main import Application, ReturnCodes, main
 from glueforward.main.qbittorrent import QBittorrentClient
 
-# Full, valid environment for _setup.
+# Full, valid environment for building an Application.
 VALID_ENV = {
     "GLUETUN_URL": "http://gluetun",
     "GLUETUN_API_KEY": "key",
@@ -29,70 +28,67 @@ def _set_valid_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(name, value)
 
 
-def test_setup_with_valid_log_level(monkeypatch):
+def test_init_with_valid_log_level(monkeypatch):
     _set_valid_env(monkeypatch)
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
 
     app = Application()
-    app._setup()
 
-    assert isinstance(app._Application__gluetun, GluetunClient)
-    assert isinstance(app._Application__service_client, QBittorrentClient)
-    assert app._Application__retry_interval == 10
-    assert app._Application__success_interval == 300
+    assert isinstance(app._gluetun, GluetunClient)
+    assert isinstance(app._service_client, QBittorrentClient)
+    assert app._retry_interval == 10
+    assert app._success_interval == 300
 
 
-def test_setup_with_invalid_log_level_defaults_to_info(monkeypatch):
+def test_init_with_invalid_log_level_defaults_to_info(monkeypatch):
     _set_valid_env(monkeypatch)
     monkeypatch.setenv("LOG_LEVEL", "NOPE")
 
-    app = Application()
-    app._setup()  # must not raise; LOG_LEVEL falls back to INFO
+    app = Application()  # must not raise; LOG_LEVEL falls back to INFO
 
-    assert isinstance(app._Application__service_client, QBittorrentClient)
+    assert isinstance(app._service_client, QBittorrentClient)
 
 
-def test_setup_missing_required_env_exits(monkeypatch):
+def test_init_missing_required_env_exits(monkeypatch):
     _set_valid_env(monkeypatch)
     monkeypatch.delenv("GLUETUN_URL")
 
-    app = Application()
     with pytest.raises(SystemExit) as exc:
-        app._setup()
+        Application()
     assert exc.value.code == ReturnCodes.MISSING_ENVIRONMENT_VARIABLE
 
 
-def test_setup_unknown_service_type_exits(monkeypatch):
+def test_init_unknown_service_type_exits(monkeypatch):
     _set_valid_env(monkeypatch)
     monkeypatch.setenv("SERVICE_TYPE", "transmission")
 
-    app = Application()
     with pytest.raises(SystemExit) as exc:
-        app._setup()
+        Application()
     assert exc.value.code == ReturnCodes.UNKNOWN_SERVICE_TYPE
 
 
-def test_loop_sets_port_from_gluetun():
+def test_loop_sets_port_from_gluetun(monkeypatch):
+    _set_valid_env(monkeypatch)
     app = Application()
     gluetun = MagicMock()
     service = MagicMock()
     gluetun.get_forwarded_port.return_value = 4242
-    app._Application__gluetun = gluetun
-    app._Application__service_client = service
+    app._gluetun = gluetun
+    app._service_client = service
 
-    app._Application__loop()
+    app._loop()
 
     service.set_port.assert_called_once_with(4242)
 
 
 def test_run_handles_lifecycle_branches(monkeypatch):
+    _set_valid_env(monkeypatch)
     app = Application()
-    app._Application__retry_interval = 0
-    app._Application__success_interval = 0
-    monkeypatch.setattr(Application, "_setup", lambda self: None)
+    app._retry_interval = 0
+    app._success_interval = 0
     monkeypatch.setattr(
         Application,
-        "_Application__loop",
+        "_loop",
         MagicMock(
             side_effect=[
                 RetryableError(message="immediate", retry_immediately=True),
@@ -114,6 +110,7 @@ def test_run_handles_lifecycle_branches(monkeypatch):
 
 
 def test_main_runs_application(monkeypatch):
+    _set_valid_env(monkeypatch)
     run = MagicMock()
     monkeypatch.setattr(Application, "run", run)
 

--- a/glueforward/tests/unit/test_qbittorrent.py
+++ b/glueforward/tests/unit/test_qbittorrent.py
@@ -2,7 +2,6 @@
 
 # The authentication state under test has no public accessor.
 # pylint: disable=protected-access
-# pyright: reportAttributeAccessIssue=false
 
 import httpx
 import pytest
@@ -35,7 +34,7 @@ def test_set_port_authenticates_then_succeeds(mock_httpx):
 
     # First call: not authenticated yet, so it authenticates first.
     client.set_port(11111)
-    assert client._QBittorrentClient__get_is_authenticated() is True
+    assert client._get_is_authenticated() is True
 
     # Second call: already authenticated, skips re-authentication.
     client.set_port(22222)
@@ -87,7 +86,7 @@ def test_set_port_session_expired(mock_httpx):
     with pytest.raises(QBittorrentAuthenticationNeeded):
         client.set_port(11111)
     # The expired session must have been reset.
-    assert client._QBittorrentClient__get_is_authenticated() is False
+    assert client._get_is_authenticated() is False
 
 
 def test_set_port_other_http_error_reraised(mock_httpx):


### PR DESCRIPTION
Follow-up to #16, which enabled pylint and pyright on the test tree and had to buy that with two file-wide suppressions and a second pylint invocation. Both were paying for name mangling.

## Why mangling bought nothing

`Application` and `GluetunClient` have no base class, and `QBittorrentClient` implements a `Protocol` declaring one method and no attributes. There was no collision to protect against.

It did cost pyright, which records a member under the name as written. From outside the class, `_Application__gluetun` is a name it has never seen declared, so it rejected every such access as an unknown attribute. Both test files carried a file-wide `reportAttributeAccessIssue` exemption to silence it, which also blinded pyright to genuine typos throughout those files.

## What changes

- `self.__x` becomes `self._x` across `glueforward/main`. `pylint`'s `protected-access` still guards production code, and is still exempted in the two test files that assert on internals.
- `Application._setup()` becomes `__init__`, with the logging configuration it also performed split out into `_configure_logging()`. `run()` no longer has a setup phase to call.
- Both `pyright: reportAttributeAccessIssue=false` exemptions are gone.
- pylint drops back to a single `pylint glueforward` invocation.

## On the constructor

`_setup()` assigned the four attributes, which pylint would have reported as `attribute-defined-outside-init` all along had they not been mangled: that check ignores mangled names. Renaming surfaced it, so the assignments move into `__init__` rather than being suppressed. Building an `Application` now reads the environment, which is what every test already arranged for it.

## Verification

`pylint glueforward` 10.00/10 in one run, `pyright glueforward` 0 errors with no exemptions left, 23 tests at 100% branch coverage, actionlint clean. Checked that the single pylint invocation still catches a regression in the test tree: an unused fixture argument still exits 4.