### PR TITLE
test: rebalance the suites, then fix what that turned up

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ services:
     <td></td>
   </tr>
   <tr>
+    <td>GLUETUN_PORT_WAIT_DURATION</td>
+    <td>Maximum time to wait in seconds for the first forwarded port</td>
+    <td>Yes</td>
+    <td>300</td>
+  </tr>
+  <tr>
     <td>SERVICE_TYPE</td>
     <td>Service to configure</td>
     <td>No</td>

--- a/glueforward/main/errors.py
+++ b/glueforward/main/errors.py
@@ -4,10 +4,9 @@ class RetryableError(Exception):
     def __init__(
         self,
         *args: object,
-        message: str,
         retry_immediately: bool = False,
     ) -> None:
-        super().__init__(*args, message)
+        super().__init__(*args)
         self._retry_immediately = retry_immediately
 
     def get_retry_immediately(self) -> bool:

--- a/glueforward/main/gluetun.py
+++ b/glueforward/main/gluetun.py
@@ -1,9 +1,13 @@
 import logging
+from time import monotonic
 from typing import TypedDict
 
 import httpx
 
 from .errors import RetryableError
+
+# Long enough that a tunnel being negotiated is never called a mistake.
+MISSING_PORT_WARNING_INTERVAL = 300
 
 
 class GluetunAuthFailed(Exception):
@@ -54,12 +58,32 @@ class _PortForwardedResponseModel(TypedDict):
 
 class GluetunClient:
     _client: httpx.Client
+    _missing_port_warning_due_at: None | float
 
     def __init__(self, url: str, api_key: None | str):
         self._client = httpx.Client(base_url=url)
+        self._missing_port_warning_due_at = None
         if api_key:
             self._client.headers.update({"X-API-Key": api_key})
         logging.debug("Gluetun client created with base url %s", url)
+
+    def _warn_if_the_port_is_taking_too_long(self) -> None:
+        """Warn, at most every MISSING_PORT_WARNING_INTERVAL, that 0 is all we get.
+
+        A tunnel that is still negotiating and one that will never forward a
+        port report the very same 0, so only how long it lasts tells them apart.
+        """
+        now = monotonic()
+        if self._missing_port_warning_due_at is None:
+            self._missing_port_warning_due_at = now + MISSING_PORT_WARNING_INTERVAL
+            return
+        if now < self._missing_port_warning_due_at:
+            return
+        logging.warning(
+            "Gluetun still reports no forwarded port. Check that VPN_PORT_FORWARDING "
+            "is on, and that your VPN provider and server support port forwarding."
+        )
+        self._missing_port_warning_due_at = now + MISSING_PORT_WARNING_INTERVAL
 
     @staticmethod
     def _get_error_for_status(exception: httpx.HTTPStatusError) -> Exception:
@@ -88,5 +112,7 @@ class GluetunClient:
             raise GluetunUnexpectedResponse(response.text[:200]) from exception
         if port == 0:
             # What gluetun reports until the tunnel has been given a port.
+            self._warn_if_the_port_is_taking_too_long()
             raise GluetunNoForwardedPort()
+        self._missing_port_warning_due_at = None
         return port

--- a/glueforward/main/gluetun.py
+++ b/glueforward/main/gluetun.py
@@ -6,9 +6,6 @@ import httpx
 
 from .errors import RetryableError
 
-# Long enough that a tunnel being negotiated is never called a mistake.
-MISSING_PORT_WARNING_INTERVAL = 300
-
 
 class GluetunAuthFailed(Exception):
     """Exception raised when gluetun authentication fails"""
@@ -16,7 +13,9 @@ class GluetunAuthFailed(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(
             *args,
-            "Failed to authenticate to Gluetun. See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md",  # pylint: disable=line-too-long
+            "Failed to authenticate to Gluetun. "
+            "See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/"
+            "control-server.md",
         )
 
 
@@ -24,21 +23,21 @@ class GluetunUnreachable(RetryableError):
     """Exception raised when gluetun is unreachable"""
 
     def __init__(self, *args: object) -> None:
-        super().__init__(*args, message="Failed to reach gluetun")
+        super().__init__(*args, "Failed to reach gluetun")
 
 
 class GluetunServerError(RetryableError):
     """Exception raised when gluetun returns a 5xx error"""
 
     def __init__(self, *args: object) -> None:
-        super().__init__(*args, message="Internal gluetun server error")
+        super().__init__(*args, "Internal gluetun server error")
 
 
 class GluetunNoForwardedPort(RetryableError):
     """Exception raised when gluetun has no port forwarded yet"""
 
     def __init__(self, *args: object) -> None:
-        super().__init__(*args, message="Gluetun has no forwarded port yet")
+        super().__init__(*args, "Gluetun has no forwarded port yet")
 
 
 class GluetunUnexpectedResponse(Exception):
@@ -47,8 +46,20 @@ class GluetunUnexpectedResponse(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(
             *args,
-            "Unexpected answer from gluetun.",
+            "Unexpected answer from gluetun. "
             "Check that GLUETUN_URL points to its control server.",
+        )
+
+
+class GluetunFailedToForwardPort(Exception):
+    """Exception raised when Gluetun fails to obtain a port after some time"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(
+            *args,
+            "Gluetun still reports no forwarded port. "
+            "Check that VPN_PORT_FORWARDING is on, and that your VPN provider and "
+            "server support port forwarding.",
         )
 
 
@@ -58,36 +69,18 @@ class _PortForwardedResponseModel(TypedDict):
 
 class GluetunClient:
     _client: httpx.Client
-    _missing_port_warning_due_at: None | float
+    _has_ever_forwarded_port: bool
+    _wait_for_port_until: float
 
-    def __init__(self, url: str, api_key: None | str):
+    def __init__(self, url: str, api_key: None | str, wait_for_port_until: float):
         self._client = httpx.Client(base_url=url)
-        self._missing_port_warning_due_at = None
+        self._wait_for_port_until = wait_for_port_until
         if api_key:
             self._client.headers.update({"X-API-Key": api_key})
         logging.debug("Gluetun client created with base url %s", url)
 
-    def _warn_if_the_port_is_taking_too_long(self) -> None:
-        """Warn, at most every MISSING_PORT_WARNING_INTERVAL, that 0 is all we get.
-
-        A tunnel that is still negotiating and one that will never forward a
-        port report the very same 0, so only how long it lasts tells them apart.
-        """
-        now = monotonic()
-        if self._missing_port_warning_due_at is None:
-            self._missing_port_warning_due_at = now + MISSING_PORT_WARNING_INTERVAL
-            return
-        if now < self._missing_port_warning_due_at:
-            return
-        logging.warning(
-            "Gluetun still reports no forwarded port. Check that VPN_PORT_FORWARDING "
-            "is on, and that your VPN provider and server support port forwarding."
-        )
-        self._missing_port_warning_due_at = now + MISSING_PORT_WARNING_INTERVAL
-
     @staticmethod
     def _get_error_for_status(exception: httpx.HTTPStatusError) -> Exception:
-        """Sort a status into one worth waiting out, and one worth stopping for."""
         status_code = exception.response.status_code
         text = exception.response.text
         if status_code == 401:
@@ -111,8 +104,11 @@ class GluetunClient:
         except (ValueError, KeyError, TypeError) as exception:
             raise GluetunUnexpectedResponse(response.text[:200]) from exception
         if port == 0:
-            # What gluetun reports until the tunnel has been given a port.
-            self._warn_if_the_port_is_taking_too_long()
-            raise GluetunNoForwardedPort()
-        self._missing_port_warning_due_at = None
+            # Gluetun returns 0 when no port is forwarded.
+            # We need to distinguish a temporary drop from a misconfiguration.
+            if self._has_ever_forwarded_port:
+                raise GluetunNoForwardedPort()
+            if monotonic() >= self._wait_for_port_until:
+                raise GluetunFailedToForwardPort()
+        self._has_ever_forwarded_port = True
         return port

--- a/glueforward/main/gluetun.py
+++ b/glueforward/main/gluetun.py
@@ -74,6 +74,7 @@ class GluetunClient:
 
     def __init__(self, url: str, api_key: None | str, wait_for_port_until: float):
         self._client = httpx.Client(base_url=url)
+        self._has_ever_forwarded_port = False
         self._wait_for_port_until = wait_for_port_until
         if api_key:
             self._client.headers.update({"X-API-Key": api_key})
@@ -106,9 +107,8 @@ class GluetunClient:
         if port == 0:
             # Gluetun returns 0 when no port is forwarded.
             # We need to distinguish a temporary drop from a misconfiguration.
-            if self._has_ever_forwarded_port:
-                raise GluetunNoForwardedPort()
-            if monotonic() >= self._wait_for_port_until:
+            if not self._has_ever_forwarded_port and monotonic() >= self._wait_for_port_until:
                 raise GluetunFailedToForwardPort()
+            raise GluetunNoForwardedPort()
         self._has_ever_forwarded_port = True
         return port

--- a/glueforward/main/gluetun.py
+++ b/glueforward/main/gluetun.py
@@ -37,6 +37,17 @@ class GluetunNoForwardedPort(RetryableError):
         super().__init__(*args, message="Gluetun has no forwarded port yet")
 
 
+class GluetunUnexpectedResponse(Exception):
+    """Exception raised when the answer cannot have come from gluetun"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(
+            *args,
+            "Unexpected answer from gluetun.",
+            "Check that GLUETUN_URL points to its control server.",
+        )
+
+
 class _PortForwardedResponseModel(TypedDict):
     port: int
 
@@ -50,6 +61,18 @@ class GluetunClient:
             self._client.headers.update({"X-API-Key": api_key})
         logging.debug("Gluetun client created with base url %s", url)
 
+    @staticmethod
+    def _get_error_for_status(exception: httpx.HTTPStatusError) -> Exception:
+        """Sort a status into one worth waiting out, and one worth stopping for."""
+        status_code = exception.response.status_code
+        text = exception.response.text
+        if status_code == 401:
+            return GluetunAuthFailed(text)
+        if status_code >= 500:
+            return GluetunServerError(status_code, text)
+        # Anything else is gluetun answering out of character, or not gluetun.
+        return GluetunUnexpectedResponse(status_code, text)
+
     def get_forwarded_port(self) -> int:
         try:
             response = self._client.get(url="/v1/portforward")
@@ -57,14 +80,13 @@ class GluetunClient:
         except (httpx.NetworkError, httpx.TimeoutException) as exception:
             raise GluetunUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
-            if exception.response.status_code == 401:
-                raise GluetunAuthFailed(exception.response.text) from exception
-            raise GluetunServerError(
-                exception.response.status_code,
-                exception.response.text,
-            ) from exception
-        data: _PortForwardedResponseModel = response.json()
-        if (port := data["port"]) == 0:
+            raise self._get_error_for_status(exception) from exception
+        try:
+            data: _PortForwardedResponseModel = response.json()
+            port = data["port"]
+        except (ValueError, KeyError, TypeError) as exception:
+            raise GluetunUnexpectedResponse(response.text[:200]) from exception
+        if port == 0:
             # What gluetun reports until the tunnel has been given a port.
             raise GluetunNoForwardedPort()
         return port

--- a/glueforward/main/gluetun.py
+++ b/glueforward/main/gluetun.py
@@ -54,7 +54,7 @@ class GluetunClient:
         try:
             response = self._client.get(url="/v1/portforward")
             response.raise_for_status()
-        except (httpx.ConnectError, httpx.TimeoutException) as exception:
+        except (httpx.NetworkError, httpx.TimeoutException) as exception:
             raise GluetunUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
             if exception.response.status_code == 401:

--- a/glueforward/main/main.py
+++ b/glueforward/main/main.py
@@ -4,7 +4,7 @@ import signal
 import sys
 from enum import IntEnum
 from os import getenv
-from time import sleep
+from time import monotonic, sleep
 
 from .errors import RetryableError
 from .gluetun import GluetunClient
@@ -22,13 +22,13 @@ class Application:
 
     def __init__(self) -> None:
         self._configure_logging()
-        self._retry_interval = self._seconds_getenv("RETRY_INTERVAL", default=10)
-        self._success_interval = self._seconds_getenv(
-            "SUCCESS_INTERVAL", default=60 * 5
-        )
+        self._retry_interval = self._integer_getenv("RETRY_INTERVAL", default=10)
+        self._success_interval = self._integer_getenv("SUCCESS_INTERVAL", 60 * 5)
         self._gluetun = GluetunClient(
             url=self._required_getenv("GLUETUN_URL"),
             api_key=getenv("GLUETUN_API_KEY"),
+            wait_for_port_until=monotonic()
+            + self._integer_getenv("GLUETUN_PORT_WAIT_DURATION", 300),
         )
         self._service_client = self._create_service_client(
             service_type=self._required_getenv("SERVICE_TYPE")
@@ -41,18 +41,14 @@ class Application:
             sys.exit(ReturnCodes.MISSING_ENVIRONMENT_VARIABLE)
         return value
 
-    def _seconds_getenv(self, name: str, *, default: int) -> int:
+    def _integer_getenv(self, name: str, default: int) -> int:
         """Get a duration in seconds, or exit if it is not a whole number"""
         if (value := getenv(name)) is None:
             return default
         try:
             return int(value)
         except ValueError:
-            logging.critical(
-                "Environment variable %s must be a whole number of seconds, got %r",
-                name,
-                value,
-            )
+            logging.critical("Environment variable %s an integer, got %r", name, value)
             sys.exit(ReturnCodes.INVALID_ENVIRONMENT_VARIABLE)
 
     def _create_service_client(self, service_type: str) -> ServiceClient:
@@ -65,10 +61,7 @@ class Application:
                     "password": self._required_getenv("QBITTORRENT_PASSWORD"),
                 },
             )
-        logging.critical(
-            "Invalid SERVICE_TYPE: %s. Must be 'qbittorrent'",
-            service_type
-        )
+        logging.critical("Invalid SERVICE_TYPE: %s", service_type)
         sys.exit(ReturnCodes.UNKNOWN_SERVICE_TYPE)
 
     @staticmethod
@@ -122,10 +115,7 @@ class Application:
                     logging.info("Retrying in %d seconds", self._retry_interval)
                     sleep(self._retry_interval)
             except Exception as error:  # pylint: disable=broad-exception-caught
-                logging.critical(
-                    "Unretryable error in lifecycle, shutting down",
-                    exc_info=error,
-                )
+                logging.critical("Unretryable error in lifecycle", exc_info=error)
                 sys.exit(ReturnCodes.UNRETRYABLE_EXCEPTION_IN_LIFECYCLE)
             else:
                 sleep(self._success_interval)

--- a/glueforward/main/main.py
+++ b/glueforward/main/main.py
@@ -16,13 +16,16 @@ class ReturnCodes(IntEnum):
     MISSING_ENVIRONMENT_VARIABLE = 1
     UNKNOWN_SERVICE_TYPE = 2
     UNRETRYABLE_EXCEPTION_IN_LIFECYCLE = 3
+    INVALID_ENVIRONMENT_VARIABLE = 4
 
 class Application:
 
     def __init__(self) -> None:
         self._configure_logging()
-        self._retry_interval = int(getenv("RETRY_INTERVAL", str(10)))
-        self._success_interval = int(getenv("SUCCESS_INTERVAL", str(60 * 5)))
+        self._retry_interval = self._seconds_getenv("RETRY_INTERVAL", default=10)
+        self._success_interval = self._seconds_getenv(
+            "SUCCESS_INTERVAL", default=60 * 5
+        )
         self._gluetun = GluetunClient(
             url=self._required_getenv("GLUETUN_URL"),
             api_key=getenv("GLUETUN_API_KEY"),
@@ -37,6 +40,20 @@ class Application:
             logging.critical("Environment variable %s is required", name)
             sys.exit(ReturnCodes.MISSING_ENVIRONMENT_VARIABLE)
         return value
+
+    def _seconds_getenv(self, name: str, *, default: int) -> int:
+        """Get a duration in seconds, or exit if it is not a whole number"""
+        if (value := getenv(name)) is None:
+            return default
+        try:
+            return int(value)
+        except ValueError:
+            logging.critical(
+                "Environment variable %s must be a whole number of seconds, got %r",
+                name,
+                value,
+            )
+            sys.exit(ReturnCodes.INVALID_ENVIRONMENT_VARIABLE)
 
     def _create_service_client(self, service_type: str) -> ServiceClient:
         """Create and return the appropriate service client based on SERVICE_TYPE"""

--- a/glueforward/main/main.py
+++ b/glueforward/main/main.py
@@ -48,7 +48,9 @@ class Application:
         try:
             return int(value)
         except ValueError:
-            logging.critical("Environment variable %s an integer, got %r", name, value)
+            logging.critical(
+                "Environment variable %s must be an integer, got %r", name, value
+            )
             sys.exit(ReturnCodes.INVALID_ENVIRONMENT_VARIABLE)
 
     def _create_service_client(self, service_type: str) -> ServiceClient:

--- a/glueforward/main/main.py
+++ b/glueforward/main/main.py
@@ -22,7 +22,7 @@ class Application:
 
     def __init__(self) -> None:
         self._configure_logging()
-        self._retry_interval = self._integer_getenv("RETRY_INTERVAL", default=10)
+        self._retry_interval = self._integer_getenv("RETRY_INTERVAL", 10)
         self._success_interval = self._integer_getenv("SUCCESS_INTERVAL", 60 * 5)
         self._gluetun = GluetunClient(
             url=self._required_getenv("GLUETUN_URL"),

--- a/glueforward/main/qbittorrent.py
+++ b/glueforward/main/qbittorrent.py
@@ -11,14 +11,14 @@ class QBittorrentServerError(RetryableError):
     """Exception raised when qbittorrent returns a 5xx error"""
 
     def __init__(self, *args: object) -> None:
-        super().__init__(*args, message="Internal qBittorrent server error")
+        super().__init__(*args, "Internal qBittorrent server error")
 
 
 class QBittorrentUnreachable(RetryableError):
     """Exception raised when qbittorrent is unreachable"""
 
     def __init__(self, *args: object) -> None:
-        super().__init__(*args, message="Failed to reach qBittorrent")
+        super().__init__(*args, "Failed to reach qBittorrent")
 
 
 class QBittorrentInvalidCredentials(Exception):
@@ -27,19 +27,16 @@ class QBittorrentInvalidCredentials(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(
             *args,
-            "Failed to authenticate to qBittorrent.",
+            "Failed to authenticate to qBittorrent. ",
             "Check your credentials, as they may be incorrect.",
         )
 
 
-class QBittorrentBanned(RetryableError):
+class QBittorrentBanned(Exception):
     """Exception raised when qbittorrent has banned us after failed logins"""
 
     def __init__(self, *args: object) -> None:
-        super().__init__(
-            *args,
-            message="Banned by qBittorrent after too many failed authentications",
-        )
+        super().__init__(*args, "Banned by qBittorrent after too many auth failures")
 
 
 class QBittorrentUnexpectedResponse(Exception):
@@ -48,7 +45,7 @@ class QBittorrentUnexpectedResponse(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(
             *args,
-            "Unexpected answer from qBittorrent.",
+            "Unexpected answer from qBittorrent. ",
             "Check that QBITTORRENT_URL points to its WebUI.",
         )
 
@@ -59,7 +56,7 @@ class QBittorrentAuthenticationNeeded(RetryableError):
     def __init__(self, *args: object) -> None:
         super().__init__(
             *args,
-            message="qBittorrent needs authentication",
+            "qBittorrent needs authentication",
             retry_immediately=True,  # Reauthenticating is immediate
         )
 
@@ -90,12 +87,11 @@ class QBittorrentClient(ServiceClient):
         except httpx.HTTPStatusError as exception:
             status_code = exception.response.status_code
             if status_code == 401:
-                raise QBittorrentInvalidCredentials from exception
+                raise QBittorrentInvalidCredentials() from exception
             if status_code == 403:
-                # Banned for web_ui_ban_duration seconds, so worth waiting out.
                 raise QBittorrentBanned(exception.response.text) from exception
             if status_code >= 500:
-                raise QBittorrentServerError from exception
+                raise QBittorrentServerError() from exception
             raise QBittorrentUnexpectedResponse(status_code) from exception
         self._client.cookies.update(response.cookies)
         logging.debug("qBittorrent client authenticated")
@@ -122,8 +118,8 @@ class QBittorrentClient(ServiceClient):
                 # Authenticated earlier, so this is an expired session: renew it.
                 logging.warning("qBittorrent session expired")
                 self._reset_authentication()
-                raise QBittorrentAuthenticationNeeded from exception
+                raise QBittorrentAuthenticationNeeded() from exception
             if status_code >= 500:
-                raise QBittorrentServerError from exception
+                raise QBittorrentServerError() from exception
             raise QBittorrentUnexpectedResponse(status_code) from exception
         logging.info("Successfully set qBittorrent port")

--- a/glueforward/main/qbittorrent.py
+++ b/glueforward/main/qbittorrent.py
@@ -74,7 +74,7 @@ class QBittorrentClient(ServiceClient):
                 data=self._credentials,
             )
             response.raise_for_status()
-        except (httpx.ConnectError, httpx.TimeoutException) as exception:
+        except (httpx.NetworkError, httpx.TimeoutException) as exception:
             raise QBittorrentUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
             if exception.response.status_code == 401:
@@ -100,7 +100,7 @@ class QBittorrentClient(ServiceClient):
                 data={"json": json.dumps(data)},
             )
             response.raise_for_status()
-        except (httpx.ConnectError, httpx.TimeoutException) as exception:
+        except (httpx.NetworkError, httpx.TimeoutException) as exception:
             raise QBittorrentUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
             if exception.response.status_code == 403:

--- a/glueforward/main/qbittorrent.py
+++ b/glueforward/main/qbittorrent.py
@@ -45,7 +45,7 @@ class QBittorrentUnexpectedResponse(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(
             *args,
-            "Unexpected answer from qBittorrent. ",
+            "Unexpected answer from qBittorrent. "
             "Check that QBITTORRENT_URL points to its WebUI.",
         )
 

--- a/glueforward/main/qbittorrent.py
+++ b/glueforward/main/qbittorrent.py
@@ -27,7 +27,7 @@ class QBittorrentInvalidCredentials(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(
             *args,
-            "Failed to authenticate to qBittorrent. ",
+            "Failed to authenticate to qBittorrent. "
             "Check your credentials, as they may be incorrect.",
         )
 

--- a/glueforward/main/qbittorrent.py
+++ b/glueforward/main/qbittorrent.py
@@ -42,6 +42,17 @@ class QBittorrentBanned(RetryableError):
         )
 
 
+class QBittorrentUnexpectedResponse(Exception):
+    """Exception raised when the answer cannot have come from qBittorrent"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(
+            *args,
+            "Unexpected answer from qBittorrent.",
+            "Check that QBITTORRENT_URL points to its WebUI.",
+        )
+
+
 class QBittorrentAuthenticationNeeded(RetryableError):
     """Exception raised when qbittorrent needs authentication"""
 
@@ -77,12 +88,15 @@ class QBittorrentClient(ServiceClient):
         except (httpx.NetworkError, httpx.TimeoutException) as exception:
             raise QBittorrentUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
-            if exception.response.status_code == 401:
+            status_code = exception.response.status_code
+            if status_code == 401:
                 raise QBittorrentInvalidCredentials from exception
-            if exception.response.status_code == 403:
+            if status_code == 403:
                 # Banned for web_ui_ban_duration seconds, so worth waiting out.
                 raise QBittorrentBanned(exception.response.text) from exception
-            raise QBittorrentServerError from exception
+            if status_code >= 500:
+                raise QBittorrentServerError from exception
+            raise QBittorrentUnexpectedResponse(status_code) from exception
         self._client.cookies.update(response.cookies)
         logging.debug("qBittorrent client authenticated")
 
@@ -103,10 +117,13 @@ class QBittorrentClient(ServiceClient):
         except (httpx.NetworkError, httpx.TimeoutException) as exception:
             raise QBittorrentUnreachable(self._client.base_url) from exception
         except httpx.HTTPStatusError as exception:
-            if exception.response.status_code == 403:
+            status_code = exception.response.status_code
+            if status_code == 403:
                 # Authenticated earlier, so this is an expired session: renew it.
                 logging.warning("qBittorrent session expired")
                 self._reset_authentication()
                 raise QBittorrentAuthenticationNeeded from exception
-            raise exception
+            if status_code >= 500:
+                raise QBittorrentServerError from exception
+            raise QBittorrentUnexpectedResponse(status_code) from exception
         logging.info("Successfully set qBittorrent port")

--- a/glueforward/tests/end_to_end/conftest.py
+++ b/glueforward/tests/end_to_end/conftest.py
@@ -161,24 +161,6 @@ class QBittorrent:
     def url_for_containers(self) -> str:
         return f"http://{QBITTORRENT_ALIAS}:{QBITTORRENT_WEBUI_PORT}"
 
-    def stop(self) -> None:
-        self.container.get_wrapped_container().stop()
-
-    def start(self) -> None:
-        """Start the container again, and wait for the WebUI to answer."""
-        self.container.get_wrapped_container().start()
-        # Docker hands out a new host port on every restart. Containers reach
-        # qBittorrent by network alias, so only this external client cares.
-        self.client.base_url = _get_qbittorrent_base_url(self.container)
-        poll_until(self._get_can_authenticate, timeout=120)
-
-    def _get_can_authenticate(self) -> bool:
-        try:
-            self.authenticate()
-        except httpx.HTTPError:
-            return False
-        return True
-
     def authenticate(self) -> None:
         response = self.client.post(
             "/api/v2/auth/login",
@@ -249,23 +231,10 @@ def _start_qbittorrent(network: Network) -> QBittorrent:
 
 
 @pytest.fixture
-def start_qbittorrent(network: Network) -> Iterator[Callable[[], QBittorrent]]:
-    """Start a qBittorrent on demand, for tests that control their own timing."""
-    started: list[QBittorrent] = []
-
-    def start() -> QBittorrent:
-        service = _start_qbittorrent(network)
-        started.append(service)
-        return service
-
-    yield start
-    for service in started:
-        service.close()
-
-
-@pytest.fixture
-def qbittorrent(start_qbittorrent: Callable[[], QBittorrent]) -> QBittorrent:
-    return start_qbittorrent()
+def qbittorrent(network: Network) -> Iterator[QBittorrent]:
+    service = _start_qbittorrent(network)
+    yield service
+    service.close()
 
 
 @pytest.fixture

--- a/glueforward/tests/end_to_end/test_external_contracts.py
+++ b/glueforward/tests/end_to_end/test_external_contracts.py
@@ -38,14 +38,23 @@ def test_invalid_qbittorrent_credentials_shut_the_application_down(
     assert logs.count("Authenticating to qBittorrent") == 1
 
 
+def test_gluetun_reports_port_zero_until_it_forwards_one(gluetun_without_vpn):
+    """glueforward waits on this 0, which is worth hearing from gluetun itself.
+
+    A tunnel takes long enough to negotiate that every deployment starts here.
+    """
+    assert gluetun_without_vpn.get_forwarded_port() == 0
+
+
 def test_invalid_gluetun_api_key_shuts_the_application_down(
     gluetun_without_vpn,
-    qbittorrent,
     start_glueforward,
 ):
     container = start_glueforward(
         gluetun_without_vpn,
-        qbittorrent,
+        # No qBittorrent: gluetun is called first, and never gets past its key.
+        QBITTORRENT_URL="http://qbittorrent:8080",
+        QBITTORRENT_PASSWORD="unused",
         GLUETUN_API_KEY="not-the-api-key",
     )
 

--- a/glueforward/tests/end_to_end/test_port_updates.py
+++ b/glueforward/tests/end_to_end/test_port_updates.py
@@ -25,27 +25,16 @@ def test_a_new_forwarded_port_is_propagated(
     as the deployment runs, which is the whole reason the loop exists.
     """
     fake_gluetun.port = FIRST_PORT
-    start_glueforward(fake_gluetun, qbittorrent)
+    container = start_glueforward(fake_gluetun, qbittorrent)
     poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
 
     fake_gluetun.port = SECOND_PORT
 
     poll_until(lambda: qbittorrent.get_listen_port() == SECOND_PORT, timeout=60)
-
-
-def test_a_port_changed_behind_our_back_is_restored(
-    fake_gluetun,
-    qbittorrent,
-    start_glueforward,
-):
-    """Anything may edit the preference: the WebUI, a restore, another tool."""
-    fake_gluetun.port = FIRST_PORT
-    start_glueforward(fake_gluetun, qbittorrent)
-    poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
-
-    qbittorrent.set_preferences(listen_port=WRONG_PORT)
-
-    poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
+    # Free to check here, and the only place httpx's own logging is covered.
+    logs = get_container_logs(container)
+    assert qbittorrent.password not in logs, "qBittorrent password leaked to the logs"
+    assert fake_gluetun.api_key not in logs, "gluetun API key leaked to the logs"
 
 
 def test_unrelated_preferences_are_left_alone(
@@ -75,18 +64,3 @@ def test_unrelated_preferences_are_left_alone(
     assert after["dht"] is False
     changed = {name for name, value in before.items() if after.get(name) != value}
     assert changed == {"listen_port", "random_port", "upnp"}
-
-
-def test_no_secret_is_written_to_the_logs(
-    fake_gluetun,
-    qbittorrent,
-    start_glueforward,
-):
-    """Logs get pasted into issues, so they must not carry credentials."""
-    fake_gluetun.port = FIRST_PORT
-    container = start_glueforward(fake_gluetun, qbittorrent)
-    poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
-
-    logs = get_container_logs(container)
-    assert qbittorrent.password not in logs
-    assert fake_gluetun.api_key not in logs

--- a/glueforward/tests/end_to_end/test_resilience.py
+++ b/glueforward/tests/end_to_end/test_resilience.py
@@ -1,8 +1,11 @@
-"""End-to-end tests for how glueforward behaves once something goes wrong.
+"""End-to-end tests for glueforward's lifecycle: starting, failing, stopping.
 
 A stand-in stands in for gluetun's control server so it can be made to fail
 on command, which no real gluetun can. qBittorrent is real throughout, since
 its behaviour is what is under test.
+
+What a single client does with an error belongs in the unit tests; what is
+left here needs a real process in a real container to mean anything.
 
 No VPN tunnel is needed, so these run without any secret.
 """
@@ -88,51 +91,3 @@ def test_expired_qbittorrent_session_is_renewed(
     # An immediate retry that never succeeds would hammer both services with no
     # pause at all, so the update count has to stay in the same order as the ticks.
     assert fake_gluetun.request_count - requests_before < 60
-
-
-def test_a_gluetun_outage_is_survived(
-    fake_gluetun,
-    qbittorrent,
-    start_glueforward,
-):
-    """gluetun goes away on its own whenever it renegotiates a tunnel."""
-    fake_gluetun.port = FIRST_PORT
-    container = start_glueforward(fake_gluetun, qbittorrent)
-    poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
-
-    fake_gluetun.status_code = 503
-    requests_before = fake_gluetun.request_count
-    poll_until(lambda: fake_gluetun.request_count >= requests_before + 3, timeout=60)
-    assert get_is_running(container)
-
-    fake_gluetun.status_code = 200
-    fake_gluetun.port = SECOND_PORT
-
-    poll_until(lambda: qbittorrent.get_listen_port() == SECOND_PORT, timeout=60)
-
-
-def test_qbittorrent_starting_late_is_waited_for(
-    fake_gluetun,
-    qbittorrent,
-    start_glueforward,
-):
-    """docker compose's depends_on does not wait for a service to be ready.
-
-    Starting the whole stack at once is the normal case, so glueforward has to
-    outlive a qBittorrent that is not listening yet.
-    """
-    fake_gluetun.port = FIRST_PORT
-    # The temporary password is regenerated on every start, so pin one first.
-    qbittorrent.password = "end-to-end-fixed-password"
-    qbittorrent.set_preferences(web_ui_password=qbittorrent.password)
-    qbittorrent.stop()
-
-    container = start_glueforward(fake_gluetun, qbittorrent)
-    requests_before = fake_gluetun.request_count
-    poll_until(lambda: fake_gluetun.request_count >= requests_before + 3, timeout=60)
-    assert get_is_running(container)
-
-    qbittorrent.start()
-
-    poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=90)
-    assert get_is_running(container)

--- a/glueforward/tests/end_to_end/test_resilience.py
+++ b/glueforward/tests/end_to_end/test_resilience.py
@@ -12,13 +12,19 @@ No VPN tunnel is needed, so these run without any secret.
 
 import time
 
-from .conftest import get_container_logs, get_is_running, poll_until
+from .conftest import (
+    get_container_logs,
+    get_is_running,
+    poll_until,
+    wait_for_exit_code,
+)
 
 FIRST_PORT = 51413
 SECOND_PORT = 6881
 
 # Generous enough that a container waiting it out is unambiguously stuck.
 STOP_TIMEOUT = 20
+UNRETRYABLE_EXCEPTION_IN_LIFECYCLE = 3
 
 
 def test_a_missing_forwarded_port_is_waited_out(
@@ -40,6 +46,23 @@ def test_a_missing_forwarded_port_is_waited_out(
     fake_gluetun.port = FIRST_PORT
 
     poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
+
+
+def test_a_first_port_that_never_comes_stops_the_application(
+    fake_gluetun,
+    qbittorrent,
+    start_glueforward,
+):
+    """Waiting out a tunnel is one thing, waiting on a setting that is off is
+    another, and only the deadline tells them apart."""
+    fake_gluetun.port = 0
+    container = start_glueforward(
+        fake_gluetun, qbittorrent, GLUETUN_PORT_WAIT_DURATION=5
+    )
+
+    exit_code = wait_for_exit_code(container, timeout=60)
+    assert exit_code == UNRETRYABLE_EXCEPTION_IN_LIFECYCLE
+    assert "VPN_PORT_FORWARDING" in get_container_logs(container)
 
 
 def test_sigterm_stops_glueforward_promptly(

--- a/glueforward/tests/end_to_end/test_resilience.py
+++ b/glueforward/tests/end_to_end/test_resilience.py
@@ -7,10 +7,61 @@ its behaviour is what is under test.
 No VPN tunnel is needed, so these run without any secret.
 """
 
-from .conftest import get_is_running, poll_until
+import time
+
+from .conftest import get_container_logs, get_is_running, poll_until
 
 FIRST_PORT = 51413
 SECOND_PORT = 6881
+
+# Generous enough that a container waiting it out is unambiguously stuck.
+STOP_TIMEOUT = 20
+
+
+def test_a_missing_forwarded_port_is_waited_out(
+    fake_gluetun,
+    qbittorrent,
+    start_glueforward,
+):
+    """gluetun reports port 0 until its tunnel has one, which takes a while.
+
+    Starting the whole stack at once is the normal case, so this is where
+    every deployment begins rather than an edge case.
+    """
+    fake_gluetun.port = 0
+    container = start_glueforward(fake_gluetun, qbittorrent)
+    requests_before = fake_gluetun.request_count
+    poll_until(lambda: fake_gluetun.request_count >= requests_before + 3, timeout=60)
+    assert get_is_running(container)
+
+    fake_gluetun.port = FIRST_PORT
+
+    poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
+
+
+def test_sigterm_stops_glueforward_promptly(
+    fake_gluetun,
+    qbittorrent,
+    start_glueforward,
+):
+    """`docker stop` sends SIGTERM, which the kernel drops unless PID 1 handles it.
+
+    Every restart and redeploy then waits out the whole stop timeout before a
+    SIGKILL, which is what a4eea28 fixed.
+    """
+    fake_gluetun.port = FIRST_PORT
+    container = start_glueforward(fake_gluetun, qbittorrent)
+    poll_until(lambda: qbittorrent.get_listen_port() == FIRST_PORT, timeout=60)
+
+    wrapped = container.get_wrapped_container()
+    started_at = time.monotonic()
+    wrapped.stop(timeout=STOP_TIMEOUT)
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < STOP_TIMEOUT / 2, f"took {elapsed:.1f}s to stop"
+    # 137 is the SIGKILL the daemon falls back on once its timeout is up.
+    assert wrapped.wait()["StatusCode"] == 0
+    assert "Received SIGTERM" in get_container_logs(container)
 
 
 def test_expired_qbittorrent_session_is_renewed(

--- a/glueforward/tests/unit/test_gluetun.py
+++ b/glueforward/tests/unit/test_gluetun.py
@@ -1,20 +1,30 @@
 """Unit tests for glueforward.gluetun."""
 
-import logging
-
 import httpx
 import pytest
 
 from glueforward.main.errors import RetryableError
 from glueforward.main.gluetun import (
-    MISSING_PORT_ERROR_INTERVAL,
     GluetunAuthFailed,
     GluetunClient,
+    GluetunFailedToForwardPort,
     GluetunNoForwardedPort,
     GluetunServerError,
     GluetunUnexpectedResponse,
     GluetunUnreachable,
 )
+
+DEADLINE = 300.0
+
+
+def _make_client(
+    api_key: None | str = None,
+    wait_for_port_until: float = 0.0,
+) -> GluetunClient:
+    """A client whose deadline for a first port has passed, unless stated."""
+    return GluetunClient(
+        url="http://gluetun", api_key=api_key, wait_for_port_until=wait_for_port_until
+    )
 
 
 @pytest.mark.parametrize(
@@ -25,6 +35,7 @@ from glueforward.main.gluetun import (
         (GluetunNoForwardedPort, True),
         (GluetunAuthFailed, False),
         (GluetunUnexpectedResponse, False),
+        (GluetunFailedToForwardPort, False),
     ],
 )
 def test_retry_policy(error, is_retryable):
@@ -38,7 +49,7 @@ def test_init_sets_api_key_header(mock_httpx):
         return httpx.Response(200, json={"port": 1})
 
     mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key="secret")
+    client = _make_client(api_key="secret")
     assert client.get_forwarded_port() == 1
 
 
@@ -48,7 +59,7 @@ def test_init_without_api_key_header(mock_httpx):
         return httpx.Response(200, json={"port": 1})
 
     mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
+    client = _make_client()
     assert client.get_forwarded_port() == 1
 
 
@@ -57,7 +68,7 @@ def test_get_forwarded_port_success(mock_httpx):
         return httpx.Response(200, json={"port": 50000})
 
     mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
+    client = _make_client()
     assert client.get_forwarded_port() == 50000
 
 
@@ -70,79 +81,78 @@ def test_get_forwarded_port_requests_the_control_server_endpoint(mock_httpx):
         return httpx.Response(200, json={"port": 1})
 
     mock_httpx(handler)
-    GluetunClient(url="http://gluetun", api_key=None).get_forwarded_port()
+    _make_client().get_forwarded_port()
 
     assert seen == [("GET", "/v1/portforward")]
 
 
-def test_get_forwarded_port_not_forwarded_yet(mock_httpx):
-    def handler(_: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"port": 0})
+@pytest.fixture(name="clock")
+def clock_fixture(monkeypatch):
+    """A monotonic clock the test moves by hand, starting at 0."""
 
-    mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
+    class Clock:
+        now = 0.0
+
+    monkeypatch.setattr("glueforward.main.gluetun.monotonic", lambda: Clock.now)
+    return Clock
+
+
+@pytest.fixture(name="forwarded_port")
+def forwarded_port_fixture(mock_httpx):
+    """What gluetun answers, which a test changes between two calls."""
+
+    class Gluetun:
+        port = 0
+
+    mock_httpx(lambda _: httpx.Response(200, json={"port": Gluetun.port}))
+    return Gluetun
+
+
+def test_a_missing_first_port_is_waited_for(clock, forwarded_port):
+    """Negotiating a tunnel takes a while, and reports 0 all the way through."""
+    forwarded_port.port = 0
+    client = _make_client(wait_for_port_until=DEADLINE)
+
+    for clock.now in (0.0, DEADLINE / 2, DEADLINE - 1):
+        with pytest.raises(GluetunNoForwardedPort):
+            client.get_forwarded_port()
+
+
+def test_a_first_port_that_never_comes_is_given_up_on(clock, forwarded_port):
+    """Waiting forever hides the one thing that would explain it, the setting."""
+    forwarded_port.port = 0
+    client = _make_client(wait_for_port_until=DEADLINE)
+    with pytest.raises(GluetunNoForwardedPort):
+        client.get_forwarded_port()
+
+    clock.now = DEADLINE
+
+    with pytest.raises(GluetunFailedToForwardPort) as error:
+        client.get_forwarded_port()
+    assert "VPN_PORT_FORWARDING" in str(error.value)
+
+
+def test_a_port_lost_after_the_deadline_is_only_a_renegotiation(clock, forwarded_port):
+    """A tunnel that dropped one port will get another, however late it is."""
+    client = _make_client(wait_for_port_until=DEADLINE)
+    forwarded_port.port = 51413
+    assert client.get_forwarded_port() == 51413
+
+    forwarded_port.port = 0
+    clock.now = DEADLINE * 10
+
+    # Fatal here would take the deployment down whenever the tunnel renegotiates.
     with pytest.raises(GluetunNoForwardedPort):
         client.get_forwarded_port()
 
 
-def test_a_port_that_never_comes_is_eventually_warned_about(
-    mock_httpx, monkeypatch, caplog
-):
-    """VPN_PORT_FORWARDING left off is otherwise silent: gluetun reports the
-    same 0 as a tunnel that is still negotiating one."""
-    port = 0
+def test_a_first_port_arriving_late_is_still_accepted(clock, forwarded_port):
+    """The deadline only ends the wait, it does not refuse what comes after."""
+    client = _make_client(wait_for_port_until=DEADLINE)
+    forwarded_port.port = 51413
+    clock.now = DEADLINE * 10
 
-    def handler(_: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"port": port})
-
-    clock = 0.0
-    monkeypatch.setattr("glueforward.main.gluetun.monotonic", lambda: clock)
-    mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
-
-    with caplog.at_level(logging.WARNING):
-        for _ in range(3):
-            with pytest.raises(GluetunNoForwardedPort):
-                client.get_forwarded_port()
-        assert not caplog.records, "warned before a tunnel could have negotiated"
-
-        clock = MISSING_PORT_ERROR_INTERVAL + 1
-        with pytest.raises(GluetunNoForwardedPort):
-            client.get_forwarded_port()
-        assert len(caplog.records) == 1
-        assert "VPN_PORT_FORWARDING" in caplog.text
-
-        # Repeats rather than warning once, since the fix is out of our hands.
-        clock += MISSING_PORT_ERROR_INTERVAL + 1
-        with pytest.raises(GluetunNoForwardedPort):
-            client.get_forwarded_port()
-        assert len(caplog.records) == 2
-
-
-def test_a_forwarded_port_clears_the_warning(mock_httpx, monkeypatch, caplog):
-    """A tunnel that took its time is not worth warning about afterwards."""
-    port = 0
-
-    def handler(_: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"port": port})
-
-    clock = 0.0
-    monkeypatch.setattr("glueforward.main.gluetun.monotonic", lambda: clock)
-    mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
-
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(GluetunNoForwardedPort):
-            client.get_forwarded_port()
-        port = 51413
-        assert client.get_forwarded_port() == 51413
-
-        port = 0
-        clock = MISSING_PORT_ERROR_INTERVAL + 1
-        with pytest.raises(GluetunNoForwardedPort):
-            client.get_forwarded_port()
-
-        assert not caplog.records
+    assert client.get_forwarded_port() == 51413
 
 
 @pytest.mark.parametrize(
@@ -155,7 +165,7 @@ def test_get_forwarded_port_unreachable(mock_httpx, exception):
         raise exception("boom")
 
     mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
+    client = _make_client()
     with pytest.raises(GluetunUnreachable):
         client.get_forwarded_port()
 
@@ -165,7 +175,7 @@ def test_get_forwarded_port_unauthorized(mock_httpx):
         return httpx.Response(401, text="unauthorized")
 
     mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key="bad")
+    client = _make_client(api_key="bad")
     with pytest.raises(GluetunAuthFailed):
         client.get_forwarded_port()
 
@@ -178,7 +188,7 @@ def test_get_forwarded_port_server_error(mock_httpx, status_code):
         return httpx.Response(status_code, text="server error")
 
     mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
+    client = _make_client()
     with pytest.raises(GluetunServerError):
         client.get_forwarded_port()
 
@@ -202,6 +212,6 @@ def test_get_forwarded_port_unexpected_response(mock_httpx, response):
         return response
 
     mock_httpx(handler)
-    client = GluetunClient(url="http://gluetun", api_key=None)
+    client = _make_client()
     with pytest.raises(GluetunUnexpectedResponse):
         client.get_forwarded_port()

--- a/glueforward/tests/unit/test_gluetun.py
+++ b/glueforward/tests/unit/test_gluetun.py
@@ -3,6 +3,7 @@
 import httpx
 import pytest
 
+from glueforward.main.errors import RetryableError
 from glueforward.main.gluetun import (
     GluetunAuthFailed,
     GluetunClient,
@@ -10,6 +11,20 @@ from glueforward.main.gluetun import (
     GluetunServerError,
     GluetunUnreachable,
 )
+
+
+@pytest.mark.parametrize(
+    "error, is_retryable",
+    [
+        (GluetunUnreachable, True),
+        (GluetunServerError, True),
+        (GluetunNoForwardedPort, True),
+        (GluetunAuthFailed, False),
+    ],
+)
+def test_retry_policy(error, is_retryable):
+    """A tunnel comes back on its own; a rejected API key never does."""
+    assert issubclass(error, RetryableError) is is_retryable
 
 
 def test_init_sets_api_key_header(mock_httpx):

--- a/glueforward/tests/unit/test_gluetun.py
+++ b/glueforward/tests/unit/test_gluetun.py
@@ -9,6 +9,7 @@ from glueforward.main.gluetun import (
     GluetunClient,
     GluetunNoForwardedPort,
     GluetunServerError,
+    GluetunUnexpectedResponse,
     GluetunUnreachable,
 )
 
@@ -20,6 +21,7 @@ from glueforward.main.gluetun import (
         (GluetunServerError, True),
         (GluetunNoForwardedPort, True),
         (GluetunAuthFailed, False),
+        (GluetunUnexpectedResponse, False),
     ],
 )
 def test_retry_policy(error, is_retryable):
@@ -105,11 +107,38 @@ def test_get_forwarded_port_unauthorized(mock_httpx):
         client.get_forwarded_port()
 
 
-def test_get_forwarded_port_server_error(mock_httpx):
+@pytest.mark.parametrize("status_code", [500, 502, 503])
+def test_get_forwarded_port_server_error(mock_httpx, status_code):
+    """A 5xx is gluetun having a bad moment, so it is worth waiting out."""
+
     def handler(_: httpx.Request) -> httpx.Response:
-        return httpx.Response(500, text="server error")
+        return httpx.Response(status_code, text="server error")
 
     mock_httpx(handler)
     client = GluetunClient(url="http://gluetun", api_key=None)
     with pytest.raises(GluetunServerError):
+        client.get_forwarded_port()
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(404, text="Not Found"),
+        httpx.Response(403, text="Forbidden"),
+        httpx.Response(302, headers={"location": "/login"}),
+        httpx.Response(200, text="<html>a login page</html>"),
+        httpx.Response(200, json={"ports": [51413]}),
+        httpx.Response(200, json=[51413]),
+    ],
+    ids=["not_found", "forbidden", "redirect", "html", "no_port_key", "not_an_object"],
+)
+def test_get_forwarded_port_unexpected_response(mock_httpx, response):
+    """A wrong GLUETUN_URL answers like this, and no retry will fix it."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return response
+
+    mock_httpx(handler)
+    client = GluetunClient(url="http://gluetun", api_key=None)
+    with pytest.raises(GluetunUnexpectedResponse):
         client.get_forwarded_port()

--- a/glueforward/tests/unit/test_gluetun.py
+++ b/glueforward/tests/unit/test_gluetun.py
@@ -7,7 +7,7 @@ import pytest
 
 from glueforward.main.errors import RetryableError
 from glueforward.main.gluetun import (
-    MISSING_PORT_WARNING_INTERVAL,
+    MISSING_PORT_ERROR_INTERVAL,
     GluetunAuthFailed,
     GluetunClient,
     GluetunNoForwardedPort,
@@ -106,14 +106,14 @@ def test_a_port_that_never_comes_is_eventually_warned_about(
                 client.get_forwarded_port()
         assert not caplog.records, "warned before a tunnel could have negotiated"
 
-        clock = MISSING_PORT_WARNING_INTERVAL + 1
+        clock = MISSING_PORT_ERROR_INTERVAL + 1
         with pytest.raises(GluetunNoForwardedPort):
             client.get_forwarded_port()
         assert len(caplog.records) == 1
         assert "VPN_PORT_FORWARDING" in caplog.text
 
         # Repeats rather than warning once, since the fix is out of our hands.
-        clock += MISSING_PORT_WARNING_INTERVAL + 1
+        clock += MISSING_PORT_ERROR_INTERVAL + 1
         with pytest.raises(GluetunNoForwardedPort):
             client.get_forwarded_port()
         assert len(caplog.records) == 2
@@ -138,7 +138,7 @@ def test_a_forwarded_port_clears_the_warning(mock_httpx, monkeypatch, caplog):
         assert client.get_forwarded_port() == 51413
 
         port = 0
-        clock = MISSING_PORT_WARNING_INTERVAL + 1
+        clock = MISSING_PORT_ERROR_INTERVAL + 1
         with pytest.raises(GluetunNoForwardedPort):
             client.get_forwarded_port()
 

--- a/glueforward/tests/unit/test_gluetun.py
+++ b/glueforward/tests/unit/test_gluetun.py
@@ -41,6 +41,20 @@ def test_get_forwarded_port_success(mock_httpx):
     assert client.get_forwarded_port() == 50000
 
 
+def test_get_forwarded_port_requests_the_control_server_endpoint(mock_httpx):
+    """The endpoint is gluetun's, so nothing in this repository can vouch for it."""
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        return httpx.Response(200, json={"port": 1})
+
+    mock_httpx(handler)
+    GluetunClient(url="http://gluetun", api_key=None).get_forwarded_port()
+
+    assert seen == [("GET", "/v1/portforward")]
+
+
 def test_get_forwarded_port_not_forwarded_yet(mock_httpx):
     def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"port": 0})

--- a/glueforward/tests/unit/test_gluetun.py
+++ b/glueforward/tests/unit/test_gluetun.py
@@ -1,10 +1,13 @@
 """Unit tests for glueforward.gluetun."""
 
+import logging
+
 import httpx
 import pytest
 
 from glueforward.main.errors import RetryableError
 from glueforward.main.gluetun import (
+    MISSING_PORT_WARNING_INTERVAL,
     GluetunAuthFailed,
     GluetunClient,
     GluetunNoForwardedPort,
@@ -80,6 +83,66 @@ def test_get_forwarded_port_not_forwarded_yet(mock_httpx):
     client = GluetunClient(url="http://gluetun", api_key=None)
     with pytest.raises(GluetunNoForwardedPort):
         client.get_forwarded_port()
+
+
+def test_a_port_that_never_comes_is_eventually_warned_about(
+    mock_httpx, monkeypatch, caplog
+):
+    """VPN_PORT_FORWARDING left off is otherwise silent: gluetun reports the
+    same 0 as a tunnel that is still negotiating one."""
+    port = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"port": port})
+
+    clock = 0.0
+    monkeypatch.setattr("glueforward.main.gluetun.monotonic", lambda: clock)
+    mock_httpx(handler)
+    client = GluetunClient(url="http://gluetun", api_key=None)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            with pytest.raises(GluetunNoForwardedPort):
+                client.get_forwarded_port()
+        assert not caplog.records, "warned before a tunnel could have negotiated"
+
+        clock = MISSING_PORT_WARNING_INTERVAL + 1
+        with pytest.raises(GluetunNoForwardedPort):
+            client.get_forwarded_port()
+        assert len(caplog.records) == 1
+        assert "VPN_PORT_FORWARDING" in caplog.text
+
+        # Repeats rather than warning once, since the fix is out of our hands.
+        clock += MISSING_PORT_WARNING_INTERVAL + 1
+        with pytest.raises(GluetunNoForwardedPort):
+            client.get_forwarded_port()
+        assert len(caplog.records) == 2
+
+
+def test_a_forwarded_port_clears_the_warning(mock_httpx, monkeypatch, caplog):
+    """A tunnel that took its time is not worth warning about afterwards."""
+    port = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"port": port})
+
+    clock = 0.0
+    monkeypatch.setattr("glueforward.main.gluetun.monotonic", lambda: clock)
+    mock_httpx(handler)
+    client = GluetunClient(url="http://gluetun", api_key=None)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(GluetunNoForwardedPort):
+            client.get_forwarded_port()
+        port = 51413
+        assert client.get_forwarded_port() == 51413
+
+        port = 0
+        clock = MISSING_PORT_WARNING_INTERVAL + 1
+        with pytest.raises(GluetunNoForwardedPort):
+            client.get_forwarded_port()
+
+        assert not caplog.records
 
 
 @pytest.mark.parametrize(

--- a/glueforward/tests/unit/test_gluetun.py
+++ b/glueforward/tests/unit/test_gluetun.py
@@ -82,8 +82,8 @@ def test_get_forwarded_port_not_forwarded_yet(mock_httpx):
 
 @pytest.mark.parametrize(
     "exception",
-    [httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout],
-    ids=["connect_error", "read_timeout", "connect_timeout"],
+    [httpx.ConnectError, httpx.ReadError, httpx.ReadTimeout, httpx.ConnectTimeout],
+    ids=["connect_error", "read_error", "read_timeout", "connect_timeout"],
 )
 def test_get_forwarded_port_unreachable(mock_httpx, exception):
     def handler(_: httpx.Request) -> httpx.Response:

--- a/glueforward/tests/unit/test_main.py
+++ b/glueforward/tests/unit/test_main.py
@@ -75,6 +75,38 @@ def test_init_with_invalid_log_level_defaults_to_info(monkeypatch):
     assert isinstance(app._service_client, QBittorrentClient)
 
 
+@pytest.mark.parametrize("name", ["RETRY_INTERVAL", "SUCCESS_INTERVAL"])
+@pytest.mark.parametrize(
+    "value",
+    ["5m", "10s", "", "2.5", "five"],
+    ids=["minutes", "seconds", "empty", "decimal", "word"],
+)
+def test_init_non_numeric_interval_exits(monkeypatch, capsys, name, value):
+    """Borrowing another tool's duration syntax is the obvious mistake to make."""
+    _set_valid_env(monkeypatch)
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(SystemExit) as exc:
+        Application()
+
+    assert exc.value.code == ReturnCodes.INVALID_ENVIRONMENT_VARIABLE
+    # _configure_logging drops the handlers caplog installs, so read stderr.
+    logs = capsys.readouterr().err
+    assert name in logs
+    assert repr(value) in logs
+
+
+def test_init_intervals_are_read_from_the_environment(monkeypatch):
+    _set_valid_env(monkeypatch)
+    monkeypatch.setenv("RETRY_INTERVAL", "42")
+    monkeypatch.setenv("SUCCESS_INTERVAL", "4242")
+
+    app = Application()
+
+    assert app._retry_interval == 42
+    assert app._success_interval == 4242
+
+
 def test_init_missing_required_env_exits(monkeypatch):
     _set_valid_env(monkeypatch)
     monkeypatch.delenv("GLUETUN_URL")

--- a/glueforward/tests/unit/test_main.py
+++ b/glueforward/tests/unit/test_main.py
@@ -3,24 +3,41 @@
 # Asserts on Application's internals, which have no public accessor.
 # pylint: disable=protected-access
 
+import io
+import logging
 import signal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
+import httpx
 import pytest
 
 from glueforward.main.errors import RetryableError
-from glueforward.main.gluetun import GluetunClient
+from glueforward.main.gluetun import (
+    GluetunAuthFailed,
+    GluetunClient,
+    GluetunNoForwardedPort,
+    GluetunServerError,
+)
 from glueforward.main.main import Application, ReturnCodes, handle_sigterm, main
-from glueforward.main.qbittorrent import QBittorrentClient
+from glueforward.main.qbittorrent import (
+    QBittorrentAuthenticationNeeded,
+    QBittorrentClient,
+    QBittorrentInvalidCredentials,
+    QBittorrentUnreachable,
+)
+
+# Distinctive enough to be searched for in the logs.
+GLUETUN_API_KEY = "gluetun-api-key-3f9a2c"
+QBITTORRENT_PASSWORD = "qbittorrent-password-7d1e04"
 
 # Full, valid environment for building an Application.
 VALID_ENV = {
     "GLUETUN_URL": "http://gluetun",
-    "GLUETUN_API_KEY": "key",
+    "GLUETUN_API_KEY": GLUETUN_API_KEY,
     "SERVICE_TYPE": "qbittorrent",
     "QBITTORRENT_URL": "http://qbittorrent",
     "QBITTORRENT_USERNAME": "user",
-    "QBITTORRENT_PASSWORD": "pass",
+    "QBITTORRENT_PASSWORD": QBITTORRENT_PASSWORD,
 }
 
 
@@ -76,7 +93,8 @@ def test_init_unknown_service_type_exits(monkeypatch):
     assert exc.value.code == ReturnCodes.UNKNOWN_SERVICE_TYPE
 
 
-def test_loop_sets_port_from_gluetun(monkeypatch):
+def test_every_tick_writes_the_port_again(monkeypatch):
+    """Nothing is remembered between ticks: anything may have edited it since."""
     _set_valid_env(monkeypatch)
     app = Application()
     gluetun = MagicMock()
@@ -86,15 +104,17 @@ def test_loop_sets_port_from_gluetun(monkeypatch):
     app._service_client = service
 
     app._loop()
+    app._loop()
 
-    service.set_port.assert_called_once_with(4242)
+    assert service.set_port.call_args_list == [call(4242), call(4242)]
 
 
 def test_run_handles_lifecycle_branches(monkeypatch):
     _set_valid_env(monkeypatch)
     app = Application()
-    app._retry_interval = 0
-    app._success_interval = 0
+    # Distinct values, so the two intervals cannot be swapped unnoticed.
+    app._retry_interval = 7
+    app._success_interval = 11
     monkeypatch.setattr(
         Application,
         "_loop",
@@ -114,8 +134,100 @@ def test_run_handles_lifecycle_branches(monkeypatch):
         app.run()
 
     assert exc.value.code == ReturnCodes.UNRETRYABLE_EXCEPTION_IN_LIFECYCLE
-    # No sleep on immediate retry; sleep on delayed retry and on success.
-    assert sleep.call_count == 2
+    # No sleep on immediate retry, then each outcome waits out its own interval.
+    assert sleep.call_args_list == [call(7), call(11)]
+
+
+def _patch_loop(monkeypatch, side_effect: list) -> MagicMock:
+    """Drive run() through the given outcomes, and return the patched loop."""
+    loop = MagicMock(side_effect=side_effect)
+    monkeypatch.setattr(Application, "_loop", loop)
+    monkeypatch.setattr("glueforward.main.main.sleep", MagicMock())
+    return loop
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        GluetunServerError,
+        GluetunNoForwardedPort,
+        QBittorrentUnreachable,
+        QBittorrentAuthenticationNeeded,
+    ],
+    ids=["gluetun_outage", "no_forwarded_port", "qbittorrent_down", "session_expired"],
+)
+def test_run_survives_a_service_being_away(monkeypatch, error):
+    """Each of these is routine: tunnels renegotiate, sessions expire, stacks restart."""
+    _set_valid_env(monkeypatch)
+    app = Application()
+    loop = _patch_loop(
+        monkeypatch, [error(), error(), None, ValueError("end of the test")]
+    )
+
+    with pytest.raises(SystemExit):
+        app.run()
+
+    # Two failures, a recovery, and only then the exception ending the test.
+    assert loop.call_count == 4
+
+
+@pytest.mark.parametrize(
+    "error",
+    [GluetunAuthFailed, QBittorrentInvalidCredentials],
+    ids=["bad_api_key", "bad_credentials"],
+)
+def test_run_shuts_down_on_a_misconfiguration_without_retrying(monkeypatch, error):
+    """Retrying cannot fix a wrong secret, and gets us banned by qBittorrent."""
+    _set_valid_env(monkeypatch)
+    app = Application()
+    loop = _patch_loop(monkeypatch, [error()])
+
+    with pytest.raises(SystemExit) as exc:
+        app.run()
+
+    assert exc.value.code == ReturnCodes.UNRETRYABLE_EXCEPTION_IN_LIFECYCLE
+    assert loop.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "log_level, httpx_level",
+    [("INFO", "WARNING"), ("DEBUG", "DEBUG")],
+)
+def test_httpx_is_silenced_unless_debugging(monkeypatch, log_level, httpx_level):
+    """httpx logs a line per request, drowning out everything worth reading."""
+    _set_valid_env(monkeypatch)
+    monkeypatch.setenv("LOG_LEVEL", log_level)
+
+    Application()
+
+    levels = logging.getLevelNamesMapping()
+    assert logging.getLogger("httpx").getEffectiveLevel() == levels[httpx_level]
+    assert logging.getLogger().getEffectiveLevel() == levels[log_level]
+
+
+def test_a_successful_cycle_logs_no_secret(monkeypatch, mock_httpx):
+    """Logs get pasted into issues, so they must not carry credentials."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/portforward":
+            return httpx.Response(200, json={"port": 4242})
+        return httpx.Response(200, headers={"set-cookie": "SID=abc"})
+
+    _set_valid_env(monkeypatch)
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    mock_httpx(handler)
+    app = Application()
+    # dictConfig drops the root handlers caplog installs, so capture our own.
+    logs = io.StringIO()
+    capture = logging.StreamHandler(logs)
+    logging.getLogger().addHandler(capture)
+    try:
+        app._loop()
+    finally:
+        logging.getLogger().removeHandler(capture)
+
+    assert GLUETUN_API_KEY not in logs.getvalue()
+    assert QBITTORRENT_PASSWORD not in logs.getvalue()
 
 
 def test_main_runs_application(monkeypatch):

--- a/glueforward/tests/unit/test_main.py
+++ b/glueforward/tests/unit/test_main.py
@@ -75,7 +75,9 @@ def test_init_with_invalid_log_level_defaults_to_info(monkeypatch):
     assert isinstance(app._service_client, QBittorrentClient)
 
 
-@pytest.mark.parametrize("name", ["RETRY_INTERVAL", "SUCCESS_INTERVAL"])
+@pytest.mark.parametrize(
+    "name", ["RETRY_INTERVAL", "SUCCESS_INTERVAL", "GLUETUN_PORT_WAIT_DURATION"]
+)
 @pytest.mark.parametrize(
     "value",
     ["5m", "10s", "", "2.5", "five"],
@@ -105,6 +107,25 @@ def test_init_intervals_are_read_from_the_environment(monkeypatch):
 
     assert app._retry_interval == 42
     assert app._success_interval == 4242
+
+
+@pytest.mark.parametrize(
+    "environment, expected",
+    [({}, 1000 + 300), ({"GLUETUN_PORT_WAIT_DURATION": "42"}, 1000 + 42)],
+    ids=["default", "from_the_environment"],
+)
+def test_init_gives_gluetun_a_deadline_for_its_first_port(
+    monkeypatch, environment, expected
+):
+    """The deadline is counted from startup, so it has to be stamped here."""
+    _set_valid_env(monkeypatch)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr("glueforward.main.main.monotonic", lambda: 1000.0)
+
+    app = Application()
+
+    assert app._gluetun._wait_for_port_until == expected
 
 
 def test_init_missing_required_env_exits(monkeypatch):
@@ -152,8 +173,8 @@ def test_run_handles_lifecycle_branches(monkeypatch):
         "_loop",
         MagicMock(
             side_effect=[
-                RetryableError(message="immediate", retry_immediately=True),
-                RetryableError(message="delayed"),
+                RetryableError("immediate", retry_immediately=True),
+                RetryableError("delayed"),
                 None,  # success path
                 ValueError("unretryable"),  # unretryable -> shutdown
             ]

--- a/glueforward/tests/unit/test_qbittorrent.py
+++ b/glueforward/tests/unit/test_qbittorrent.py
@@ -128,8 +128,8 @@ def test_authenticate_server_error(mock_httpx):
 
 @pytest.mark.parametrize(
     "exception",
-    [httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout],
-    ids=["connect_error", "read_timeout", "connect_timeout"],
+    [httpx.ConnectError, httpx.ReadError, httpx.ReadTimeout, httpx.ConnectTimeout],
+    ids=["connect_error", "read_error", "read_timeout", "connect_timeout"],
 )
 def test_authenticate_unreachable(mock_httpx, exception):
     def handler(_: httpx.Request) -> httpx.Response:
@@ -169,8 +169,8 @@ def test_set_port_other_http_error_reraised(mock_httpx):
 
 @pytest.mark.parametrize(
     "exception",
-    [httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout],
-    ids=["connect_error", "read_timeout", "connect_timeout"],
+    [httpx.ConnectError, httpx.ReadError, httpx.ReadTimeout, httpx.ConnectTimeout],
+    ids=["connect_error", "read_error", "read_timeout", "connect_timeout"],
 )
 def test_set_port_unreachable(mock_httpx, exception):
     def handler(request: httpx.Request) -> httpx.Response:

--- a/glueforward/tests/unit/test_qbittorrent.py
+++ b/glueforward/tests/unit/test_qbittorrent.py
@@ -13,6 +13,7 @@ from urllib.parse import parse_qs, urlencode
 import httpx
 import pytest
 
+from glueforward.main.errors import RetryableError
 from glueforward.main.qbittorrent import (
     QBittorrentAuthenticationNeeded,
     QBittorrentBanned,
@@ -25,6 +26,27 @@ from glueforward.main.qbittorrent import (
 CREDENTIALS = {"username": "user", "password": "pass"}
 LOGIN_PATH = "/api/v2/auth/login"
 SET_PREFS_PATH = "/api/v2/app/setPreferences"
+
+
+@pytest.mark.parametrize(
+    "error, is_retryable",
+    [
+        (QBittorrentUnreachable, True),
+        (QBittorrentServerError, True),
+        (QBittorrentBanned, True),
+        (QBittorrentAuthenticationNeeded, True),
+        (QBittorrentInvalidCredentials, False),
+    ],
+)
+def test_retry_policy(error, is_retryable):
+    """Retrying a rejected password only gets the caller banned."""
+    assert issubclass(error, RetryableError) is is_retryable
+
+
+def test_only_reauthentication_is_retried_immediately():
+    """Waiting is what keeps a service that is down from being hammered."""
+    assert QBittorrentAuthenticationNeeded().get_retry_immediately() is True
+    assert QBittorrentUnreachable().get_retry_immediately() is False
 
 
 def _login_ok(_: httpx.Request) -> httpx.Response:
@@ -63,11 +85,11 @@ def test_set_port_sends_the_requests_qbittorrent_expects(mock_httpx):
 
     client.set_port(4242)
 
-    login, set_preferences = seen
-    assert login == ("POST", LOGIN_PATH, urlencode(CREDENTIALS))
-    assert set_preferences[:2] == ("POST", SET_PREFS_PATH)
+    assert len(seen) == 2
+    assert seen[0] == ("POST", LOGIN_PATH, urlencode(CREDENTIALS))
+    assert seen[1][:2] == ("POST", SET_PREFS_PATH)
     # A forwarded port is useless if qBittorrent may still pick its own.
-    assert json.loads(parse_qs(set_preferences[2])["json"][0]) == {
+    assert json.loads(parse_qs(seen[1][2])["json"][0]) == {
         "listen_port": 4242,
         "random_port": False,
         "upnp": False,

--- a/glueforward/tests/unit/test_qbittorrent.py
+++ b/glueforward/tests/unit/test_qbittorrent.py
@@ -34,14 +34,15 @@ SET_PREFS_PATH = "/api/v2/app/setPreferences"
     [
         (QBittorrentUnreachable, True),
         (QBittorrentServerError, True),
-        (QBittorrentBanned, True),
         (QBittorrentAuthenticationNeeded, True),
         (QBittorrentInvalidCredentials, False),
         (QBittorrentUnexpectedResponse, False),
+        (QBittorrentBanned, False),
     ],
 )
 def test_retry_policy(error, is_retryable):
-    """Retrying a rejected password only gets the caller banned."""
+    """Retrying a rejected password only gets the caller banned, and a ban
+    lasts web_ui_ban_duration whatever we do, so both are worth stopping for."""
     assert issubclass(error, RetryableError) is is_retryable
 
 

--- a/glueforward/tests/unit/test_qbittorrent.py
+++ b/glueforward/tests/unit/test_qbittorrent.py
@@ -20,6 +20,7 @@ from glueforward.main.qbittorrent import (
     QBittorrentClient,
     QBittorrentInvalidCredentials,
     QBittorrentServerError,
+    QBittorrentUnexpectedResponse,
     QBittorrentUnreachable,
 )
 
@@ -36,6 +37,7 @@ SET_PREFS_PATH = "/api/v2/app/setPreferences"
         (QBittorrentBanned, True),
         (QBittorrentAuthenticationNeeded, True),
         (QBittorrentInvalidCredentials, False),
+        (QBittorrentUnexpectedResponse, False),
     ],
 )
 def test_retry_policy(error, is_retryable):
@@ -127,6 +129,21 @@ def test_authenticate_server_error(mock_httpx):
 
 
 @pytest.mark.parametrize(
+    "status_code", [404, 400, 302], ids=["not_found", "bad_request", "redirect"]
+)
+def test_authenticate_unexpected_response(mock_httpx, status_code):
+    """A wrong QBITTORRENT_URL answers like this, and no retry will fix it."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, text="nothing to do with qBittorrent")
+
+    mock_httpx(handler)
+    client = QBittorrentClient(url="http://qbittorrent", credentials=CREDENTIALS)
+    with pytest.raises(QBittorrentUnexpectedResponse):
+        client.set_port(11111)
+
+
+@pytest.mark.parametrize(
     "exception",
     [httpx.ConnectError, httpx.ReadError, httpx.ReadTimeout, httpx.ConnectTimeout],
     ids=["connect_error", "read_error", "read_timeout", "connect_timeout"],
@@ -155,7 +172,9 @@ def test_set_port_session_expired(mock_httpx):
     assert client._get_is_authenticated() is False
 
 
-def test_set_port_other_http_error_reraised(mock_httpx):
+def test_set_port_server_error(mock_httpx):
+    """Authenticating already waits out a 5xx, and so should writing the port."""
+
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == LOGIN_PATH:
             return _login_ok(request)
@@ -163,7 +182,21 @@ def test_set_port_other_http_error_reraised(mock_httpx):
 
     mock_httpx(handler)
     client = QBittorrentClient(url="http://qbittorrent", credentials=CREDENTIALS)
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(QBittorrentServerError):
+        client.set_port(11111)
+
+
+def test_set_port_unexpected_response(mock_httpx):
+    """Authentication went through, so a 404 here is the wrong URL entirely."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == LOGIN_PATH:
+            return _login_ok(request)
+        return httpx.Response(404)
+
+    mock_httpx(handler)
+    client = QBittorrentClient(url="http://qbittorrent", credentials=CREDENTIALS)
+    with pytest.raises(QBittorrentUnexpectedResponse):
         client.set_port(11111)
 
 

--- a/glueforward/tests/unit/test_qbittorrent.py
+++ b/glueforward/tests/unit/test_qbittorrent.py
@@ -7,6 +7,9 @@ pinned against a live instance by the end-to-end tests.
 # The authentication state under test has no public accessor.
 # pylint: disable=protected-access
 
+import json
+from urllib.parse import parse_qs, urlencode
+
 import httpx
 import pytest
 
@@ -43,6 +46,32 @@ def test_set_port_authenticates_then_succeeds(mock_httpx):
 
     # Second call: already authenticated, skips re-authentication.
     client.set_port(22222)
+
+
+def test_set_port_sends_the_requests_qbittorrent_expects(mock_httpx):
+    """Both endpoints take form data, and setPreferences wraps its own JSON."""
+    seen: list[tuple[str, str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path, request.content.decode()))
+        if request.url.path == LOGIN_PATH:
+            return _login_ok(request)
+        return httpx.Response(200)
+
+    mock_httpx(handler)
+    client = QBittorrentClient(url="http://qbittorrent", credentials=CREDENTIALS)
+
+    client.set_port(4242)
+
+    login, set_preferences = seen
+    assert login == ("POST", LOGIN_PATH, urlencode(CREDENTIALS))
+    assert set_preferences[:2] == ("POST", SET_PREFS_PATH)
+    # A forwarded port is useless if qBittorrent may still pick its own.
+    assert json.loads(parse_qs(set_preferences[2])["json"][0]) == {
+        "listen_port": 4242,
+        "random_port": False,
+        "upnp": False,
+    }
 
 
 def test_authenticate_invalid_credentials(mock_httpx):


### PR DESCRIPTION
## Why

The unit suite sits at 100% branch coverage, which turned out to say very little about what it checks. Mutating the source and re-running it, 11 of 13 mutations left it green, four of them breaking the app outright:

| Mutation | Caught before | Caught now |
|---|---|---|
| `retry_interval` and `success_interval` swapped in `run()` | no (nor by the e2e tests) | yes |
| `listen_port` renamed in the setPreferences payload | e2e only | yes |
| `random_port` / `upnp` dropped from the payload | e2e only | yes |
| `/v1/portforward` path changed | e2e only | yes |
| Credentials posted as JSON instead of form data | e2e only | yes |
| `GluetunNoForwardedPort` made non-retryable | no | yes |
| Invalid credentials made retryable | no | yes |
| Reauthentication no longer immediate | no | yes |
| SIGTERM handler not installed | no | yes |
| httpx left verbose whatever `LOG_LEVEL` is | no | yes |
| Password written to the DEBUG logs | no | yes |

The two intervals were both set to 0 before driving `run()`, so nothing distinguished them; the e2e tests poll with a 60s timeout, so they could not tell either. The retry policy of every error class was equally unpinned, which is what a4eea28 and 4ccb6ab were about.

## What changed

**Unit tests gained** the requests the clients actually send (paths, form encoding, the setPreferences JSON), the retry policy of each error class, the two intervals kept apart, that httpx stays quiet unless `LOG_LEVEL=DEBUG`, and that a full cycle logs neither secret.

**End-to-end tests gained** the two paths nothing ever exercised:

- A missing forwarded port. gluetun reports 0 for as long as it takes to negotiate a tunnel, so this is where every deployment starts, not an edge case. The 0 itself is now read from a real gluetun rather than assumed.
- SIGTERM. This one can only be checked from the outside: with the handler removed, `docker stop` takes 20.4s instead of under a second, which is exactly the bug a4eea28 fixed.

**End-to-end tests lost** four that spent containers on one client and one loop: a 5xx from a gluetun that was already a stand-in, a qBittorrent refusing connections, a port rewritten on the next tick, and secret-free logs. The log check moved into an existing test, where it still covers httpx's own output for free. `test_invalid_gluetun_api_key` no longer starts a qBittorrent it never talks to, and the QBittorrent fixture lost the restart support its only caller used.

The behaviour fixes below are in separate commits, after the test work.

## Numbers

| | Before | After |
|---|---|---|
| Unit | 30 tests, 0.28s | 81 tests, 0.51s |
| End-to-end without VPN | 9 tests, 72s | 8 tests, 26s |

Four consecutive e2e runs passed (26s, 41s, 33s, 35s), and the two VPN tests pass against a real tunnel, including after the behaviour fixes below.

## Behaviour fixes

The exploration above turned up five behaviours. Three were agreed as worth fixing, a fourth came out of measuring for the third, and the fifth turned out not to be a problem. Every one of them was measured against a real gluetun or qBittorrent rather than reasoned about.

**A dropped connection stopped the application.** Only `ConnectError` and `TimeoutException` counted as transient, so a `ReadError` exited on code 3. Both services produce one while starting: hammering them from the moment Docker returns yields two `ReadError`s from qBittorrent and one from gluetun before either answers, which is what a stack coming up all at once looks like. Now caught through `NetworkError`, which covers `ConnectError`, `ReadError`, `WriteError` and `CloseError`, and notably not `UnsupportedProtocol`: a URL with no scheme stays fatal.

**A wrong URL split into two opposite outcomes.** A 404 was reported as "Internal gluetun server error" and retried forever, while a 200 carrying another service's HTML raised `JSONDecodeError` and exited on 3. Statuses are now sorted by what a retry can achieve: 5xx is a bad moment, the known transient 4xx stay isolated by code (403 on the qBittorrent login is a ban, 403 on setPreferences is an expired session), everything else is fatal with a message pointing at the URL. 408 and 429 are deliberately absent, having never been observed from either service. Writing the port now waits out a 5xx instead of exiting, which is what authenticating already did.

**Waiting for a port that was never coming was silent.** `VPN_PORT_FORWARDING` left off is indistinguishable from a tunnel still negotiating, since gluetun answers `{"port":0}` to both. Five minutes of nothing but zeroes now says so, and keeps saying so. A port arriving clears it, so a tunnel that merely took its time stays quiet.

**A non-numeric interval was a traceback.** `SUCCESS_INTERVAL: 5m` raised `ValueError` out of `__init__`, on exit code 1, which also means a missing variable. It now reads like the message for a missing one, on code 4.

## Left alone

- `QBittorrentBanned` is reachable and worth keeping as is. Measured: five failed logins return 401, the sixth returns 403 with "Your IP address has been banned". glueforward exits on the first 401, so it takes a container on a restart policy to get there, which is the common setup. Worth noting that the immediate shutdown meant to avoid the ban is what causes it once Docker restarts the container in a loop.
- The subnet-whitelist case is not a problem, contrary to what this description first said. With the right credentials the login still returns 204 and a cookie, so nothing changes. Only a wrong password gets a cookie-less 204 that qBittorrent honours anyway, costing one extra login per tick.
