### PR TITLE
Document the exit codes, and release 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,17 +139,7 @@ Any code other than 0 is a mistake in the setup.
 > Leave the glueforward container on `restart: "no"` or `restart: on-failure:3`.  
 > Glueforward is built to tolerate transitive errors. Restarting-looping would hammer gluetun and the service without fixing the issue. Use `docker logs` to diagnose crashes.  
 
-## Migration : v2.0 -> v2.1
-
-Two things changed for an existing deployment.
-
-- **The wait for a first forwarded port is now bounded.**  
-  When gluetun still reports no forwarded port `GLUETUN_PORT_WAIT_DURATION` seconds (300 by default) after startup, glueforward stops instead of retrying forever. This surfaces a VPN that is never going to forward a port, typically running without `VPN_PORT_FORWARDING`, or on a provider or server that does not support it. Raise `GLUETUN_PORT_WAIT_DURATION` if your tunnel legitimately takes longer to negotiate its first port. Once a first port has arrived, later disappearances are retried indefinitely, as before.
-
-- **`GLUETUN_API_KEY` is now optional.**  
-  Leave it unset when gluetun's control server is set up for unauthenticated access. There is nothing to do if you already set it.
-
-### Coming from v1 with slskd? 
+## Coming from v1 with slskd?
 
 Support for it was removed in v2.0.0, since slskd forwards ports natively as of its v0.24.4. Configure it through [slskd's own VPN integration](https://github.com/slskd/slskd/blob/master/docs/config.md#vpn), and drop the glueforward container.
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ services:
   <tr>
     <td>SERVICE_TYPE</td>
     <td>Service to configure</td>
-    <td>No</td>
-    <td></td>
+    <td>Yes</td>
+    <td>qbittorrent</td>
   </tr>
   <tr>
     <td>QBITTORRENT_URL</td>
@@ -121,7 +121,7 @@ services:
 
 1. Required unless gluetun is setup for unauthenticated access (non default)  
    See the [gluetun control server documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication-methods) for details.
-2. Required when SERVICE_TYPE=qbittorrent, which is the only supported service at the moment.
+2. Required when SERVICE_TYPE=qbittorrent, its default value and the only supported service at the moment.
 
 ## Exit codes
 
@@ -135,16 +135,13 @@ services:
 
 Any code other than 0 is a mistake in the setup.
 
- [!IMPORTANT]  
+> [!IMPORTANT]  
 > Leave the glueforward container on `restart: "no"` or `restart: on-failure:3`.  
 > Glueforward is built to tolerate transitive errors. Restarting-looping would hammer gluetun and the service without fixing the issue. Use `docker logs` to diagnose crashes.  
 
 ## Migration : v2 -> v3
 
-Three things changed for an existing deployment.
-
-- **`SERVICE_TYPE` is now required.**  
-  It used to be optional, and to default to `qbittorrent`. A container that does not set it now stops on startup with exit code 1.
+Two things changed for an existing deployment.
 
 - **The wait for a first forwarded port is now bounded.**  
   When gluetun still reports no forwarded port `GLUETUN_PORT_WAIT_DURATION` seconds (300 by default) after startup, glueforward stops instead of retrying forever. This surfaces a VPN that is never going to forward a port, typically running without `VPN_PORT_FORWARDING`, or on a provider or server that does not support it. Raise `GLUETUN_PORT_WAIT_DURATION` if your tunnel legitimately takes longer to negotiate its first port. Once a first port has arrived, later disappearances are retried indefinitely, as before.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ services:
 
 ## Exit codes
 
-glueforward retries whatever a retry can fix, and stops otherwise. Its exit code says which.
-
 | Code | Meaning |
 | ---- | ------- |
 | 0 | Stopped on SIGTERM, the signal `docker stop` sends. |
@@ -135,19 +133,28 @@ glueforward retries whatever a retry can fix, and stops otherwise. Its exit code
 | 3 | An error no retry can fix: credentials gluetun or qBittorrent rejected, a URL that does not point at the expected API, or a first forwarded port that never came. |
 | 4 | An environment variable that has to be a whole number holds something else. |
 
-Any code other than 0 is a mistake in the setup, waiting for whoever runs it. Leave the glueforward container on `restart: "no"` (the default) so it stays stopped, with its last log lines saying why, rather than restarting into the same error and hammering gluetun and your service. Nothing is lost by doing so: unreachable servers, 5xx answers, expired sessions and a port that comes and goes are all retried in place, without the process ever exiting.
+Any code other than 0 is a mistake in the setup.
 
-## Migrating from v2
+ [!IMPORTANT]  
+> Leave the glueforward container on `restart: "no"` or `restart: on-failure:3`.  
+> Glueforward is built to tolerate transitive errors. Restarting-looping would hammer gluetun and the service without fixing the issue. Use `docker logs` to diagnose crashes.  
+
+## Migration : v2 -> v3
 
 Three things changed for an existing deployment.
 
-**`SERVICE_TYPE` is now required.** It used to be optional, and to default to `qbittorrent`. A container that does not set it now stops on startup with exit code 1.
+- **`SERVICE_TYPE` is now required.**  
+  It used to be optional, and to default to `qbittorrent`. A container that does not set it now stops on startup with exit code 1.
 
-**The wait for a first forwarded port is now bounded.** When gluetun still reports no forwarded port `GLUETUN_PORT_WAIT_DURATION` seconds (300 by default) after startup, glueforward stops with exit code 3 instead of retrying forever. This surfaces a VPN that is never going to forward a port, typically one running without `VPN_PORT_FORWARDING`, or on a provider or server that does not support it. Raise `GLUETUN_PORT_WAIT_DURATION` if your tunnel legitimately takes longer to negotiate its first port. Once a first port has arrived, later disappearances are retried indefinitely, as before.
+- **The wait for a first forwarded port is now bounded.**  
+  When gluetun still reports no forwarded port `GLUETUN_PORT_WAIT_DURATION` seconds (300 by default) after startup, glueforward stops instead of retrying forever. This surfaces a VPN that is never going to forward a port, typically running without `VPN_PORT_FORWARDING`, or on a provider or server that does not support it. Raise `GLUETUN_PORT_WAIT_DURATION` if your tunnel legitimately takes longer to negotiate its first port. Once a first port has arrived, later disappearances are retried indefinitely, as before.
 
-**`GLUETUN_API_KEY` is now optional.** Leave it unset when gluetun's control server is set up for unauthenticated access. There is nothing to do if you already set it.
+- **`GLUETUN_API_KEY` is now optional.**  
+  Leave it unset when gluetun's control server is set up for unauthenticated access. There is nothing to do if you already set it.
 
-Coming from v1 with slskd? Support for it was removed in v2.0.0, since slskd forwards ports natively as of its v0.24.4. Configure it through [slskd's own VPN integration](https://github.com/slskd/slskd/blob/master/docs/config.md#vpn), and drop the glueforward container.
+### Coming from v1 with slskd? 
+
+Support for it was removed in v2.0.0, since slskd forwards ports natively as of its v0.24.4. Configure it through [slskd's own VPN integration](https://github.com/slskd/slskd/blob/master/docs/config.md#vpn), and drop the glueforward container.
 
 ## Other info
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ services:
   glueforward:
     image: ghcr.io/geoffreycoulaud/glueforward:latest
     container_name: glueforward
+    # A non-zero exit is a setup mistake to fix, not something to restart into
+    restart: "no"
     environment:
       GLUETUN_URL: "..."
       GLUETUN_API_KEY: "..."
@@ -121,6 +123,20 @@ services:
    See the [gluetun control server documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication-methods) for details.
 2. Required when SERVICE_TYPE=qbittorrent, which is the only supported service at the moment.
 
+## Exit codes
+
+glueforward retries whatever a retry can fix, and stops otherwise. Its exit code says which.
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Stopped on SIGTERM, the signal `docker stop` sends. |
+| 1 | A required environment variable is missing. |
+| 2 | `SERVICE_TYPE` names a service that is not supported. |
+| 3 | An error no retry can fix: credentials gluetun or qBittorrent rejected, a URL that does not point at the expected API, or a first forwarded port that never came. |
+| 4 | An environment variable that has to be a whole number holds something else. |
+
+Any code other than 0 is a mistake in the setup, waiting for whoever runs it. Leave the glueforward container on `restart: "no"` (the default) so it stays stopped, with its last log lines saying why, rather than restarting into the same error and hammering gluetun and your service. Nothing is lost by doing so: unreachable servers, 5xx answers, expired sessions and a port that comes and goes are all retried in place, without the process ever exiting.
+
 ## Migrating from v2
 
 Three things changed for an existing deployment.
@@ -131,7 +147,7 @@ Three things changed for an existing deployment.
 
 **`GLUETUN_API_KEY` is now optional.** Leave it unset when gluetun's control server is set up for unauthenticated access. There is nothing to do if you already set it.
 
-Coming from v1 with slskd? Support for it was removed in v2.0.0, since slskd forwards ports natively as of its v0.24.4. See the [v2.0.0 README](https://github.com/GeoffreyCoulaud/glueforward/blob/v2.0.0/README.md#migrating-from-v1-slskd-users) for that migration.
+Coming from v1 with slskd? Support for it was removed in v2.0.0, since slskd forwards ports natively as of its v0.24.4. Configure it through [slskd's own VPN integration](https://github.com/slskd/slskd/blob/master/docs/config.md#vpn), and drop the glueforward container.
 
 ## Other info
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Any code other than 0 is a mistake in the setup.
 > Leave the glueforward container on `restart: "no"` or `restart: on-failure:3`.  
 > Glueforward is built to tolerate transitive errors. Restarting-looping would hammer gluetun and the service without fixing the issue. Use `docker logs` to diagnose crashes.  
 
-## Migration : v2 -> v3
+## Migration : v2.0 -> v2.1
 
 Two things changed for an existing deployment.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ services:
    See the [gluetun control server documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication-methods) for details.
 2. Required when SERVICE_TYPE=qbittorrent, which is the only supported service at the moment.
 
+## Migrating from v2
+
+Three things changed for an existing deployment.
+
+**`SERVICE_TYPE` is now required.** It used to be optional, and to default to `qbittorrent`. A container that does not set it now stops on startup with exit code 1.
+
+**The wait for a first forwarded port is now bounded.** When gluetun still reports no forwarded port `GLUETUN_PORT_WAIT_DURATION` seconds (300 by default) after startup, glueforward stops with exit code 3 instead of retrying forever. This surfaces a VPN that is never going to forward a port, typically one running without `VPN_PORT_FORWARDING`, or on a provider or server that does not support it. Raise `GLUETUN_PORT_WAIT_DURATION` if your tunnel legitimately takes longer to negotiate its first port. Once a first port has arrived, later disappearances are retried indefinitely, as before.
+
+**`GLUETUN_API_KEY` is now optional.** Leave it unset when gluetun's control server is set up for unauthenticated access. There is nothing to do if you already set it.
+
+Coming from v1 with slskd? Support for it was removed in v2.0.0, since slskd forwards ports natively as of its v0.24.4. See the [v2.0.0 README](https://github.com/GeoffreyCoulaud/glueforward/blob/v2.0.0/README.md#migrating-from-v1-slskd-users) for that migration.
+
 ## Other info
 
 - Ensure that gluetun and your service are reachable from glueforward.

--- a/glueforward/main/config.py
+++ b/glueforward/main/config.py
@@ -63,8 +63,8 @@ def _get_integer(name: str, default: int) -> int:
 
 
 def _get_service_config() -> ServiceConfig:
-    """Read the configuration of the one service SERVICE_TYPE names."""
-    service_type = _get_required("SERVICE_TYPE")
+    """Read the configuration of the service SERVICE_TYPE names, qBittorrent by default."""
+    service_type = getenv("SERVICE_TYPE", QBITTORRENT_SERVICE_TYPE)
     if service_type != QBITTORRENT_SERVICE_TYPE:
         raise ConfigurationError(
             ReturnCodes.UNKNOWN_SERVICE_TYPE,

--- a/glueforward/tests/unit/test_config.py
+++ b/glueforward/tests/unit/test_config.py
@@ -58,7 +58,6 @@ def test_a_missing_gluetun_api_key_is_allowed(monkeypatch):
     "name",
     [
         "GLUETUN_URL",
-        "SERVICE_TYPE",
         "QBITTORRENT_URL",
         "QBITTORRENT_USERNAME",
         "QBITTORRENT_PASSWORD",
@@ -92,6 +91,15 @@ def test_a_non_numeric_interval_is_reported(monkeypatch, name, value):
     assert error.value.return_code == ReturnCodes.INVALID_ENVIRONMENT_VARIABLE
     assert name in str(error.value)
     assert repr(value) in str(error.value)
+
+
+def test_a_missing_service_type_means_qbittorrent(monkeypatch):
+    """The only service supported so far does not have to be asked for."""
+    monkeypatch.delenv("SERVICE_TYPE")
+
+    assert get_configuration().service == QBittorrentConfig(
+        url="http://qbittorrent", username="user", password=QBITTORRENT_PASSWORD
+    )
 
 
 def test_an_unknown_service_type_is_reported(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "glueforward"
-version = "3.0.0"
+version = "2.1.0"
 description = "Update listening ports to match gluetun's forwarded port on the VPN side"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "glueforward"
-version = "3.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What

- Documents the exit codes the container stops on, and the restart policy that goes with them: a non-zero exit is a setup mistake waiting for a person, not something to restart into.
- Gives `SERVICE_TYPE` its default (`qbittorrent`) back. Requiring it would have broken 2.0 deployments that never had to name the only service there is. An unknown value stays an error, since that one is a typo.
- Releases this as 2.1.0 rather than 3.0.0, and relocks `uv.lock` accordingly. The lock pins the project's own version, and the `Dockerfile` runs `uv sync --locked`, so it had to follow.
- Points slskd users coming from v1 at slskd's own VPN integration, which replaced glueforward for them in 2.0.0.

## Why 2.1.0 rather than 3.0.0

The only behaviour a 2.0 deployment can notice is the bounded wait for a first forwarded port: glueforward now stops with exit code 3 when gluetun still reports none after `GLUETUN_PORT_WAIT_DURATION` seconds (300 by default), instead of retrying forever. That stops a container that was never going to work, typically one running without `VPN_PORT_FORWARDING`. Everything else is additive, and no service was added since 2.0.

What changed since 2.0 belongs in the release notes rather than the README, so no migration section is added here.

## Checks

`pytest` (111 tests, 100% branch coverage), `pylint`, `pyright` and `uv sync --locked` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)